### PR TITLE
Fix model config and chapter workflow bugs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,9 +19,8 @@ src/test-helpers/*
 !src/test-helpers/load-test-env.ts
 **/*.test.ts
 **/*.test.tsx
-!src/test-helpers/
-!src/test-helpers/load-test-env.ts
 !src/lib/chat-copy-content.test.ts
+!src/lib/dashboard-issue-actions.test.ts
 !src/lib/tauri-fetch.test.ts
 !src/lib/novel/start-review-run.test.ts
 

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,8 @@ release-portable-backup/
 release-github/
 src-tauri/target/
 *.tsbuildinfo
+.env
+.env.*
 
 # === 依赖 ===
 node_modules/
@@ -17,6 +19,11 @@ src/test-helpers/*
 !src/test-helpers/load-test-env.ts
 **/*.test.ts
 **/*.test.tsx
+!src/test-helpers/
+!src/test-helpers/load-test-env.ts
+!src/lib/chat-copy-content.test.ts
+!src/lib/tauri-fetch.test.ts
+!src/lib/novel/start-review-run.test.ts
 
 # === 根目录文档（仅本地保留）===
 /docs/

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,7 +5,7 @@ import { useReviewStore } from "@/stores/review-store"
 import { isTauri, pickDirectory } from "@/lib/platform"
 import { useChatStore } from "@/stores/chat-store"
 import { listDirectory, openProject, fileExists } from "@/commands/fs"
-import { getLastProject, getRecentProjects, saveLastProject, loadLlmConfig, loadLanguage, loadEmbeddingConfig, loadProviderConfigs, loadActivePresetId, loadProxyConfig, loadClipServerConfig, loadScheduledImportConfig, saveScheduledImportConfig, loadSourceWatchConfig, loadNovelMode, loadNovelConfig, loadRevisionFeedbackWindowConfig, loadTheme, saveLlmConfig } from "@/lib/project-store"
+import { getLastProject, getRecentProjects, saveLastProject, loadLlmConfig, loadLanguage, loadEmbeddingConfig, loadProviderConfigs, loadActivePresetId, loadProxyConfig, loadClipServerConfig, loadScheduledImportConfig, saveScheduledImportConfig, loadSourceWatchConfig, loadNovelMode, loadNovelConfig, loadRevisionFeedbackWindowConfig, loadTheme, saveLlmConfig, saveProviderConfigs, saveActivePresetId } from "@/lib/project-store"
 import { loadNovelProjectMeta } from "@/lib/novel/project-meta"
 import { loadReviewItems, loadChatHistory } from "@/lib/persist"
 import { setupAutoSave } from "@/lib/auto-save"
@@ -20,6 +20,7 @@ import { formatAppTitle } from "@/lib/app-title"
 import { resetProjectState, resetProjectStores } from "@/lib/reset-project-state"
 import { LLM_PRESETS } from "@/components/settings/llm-presets"
 import { resolveConfig } from "@/components/settings/preset-resolver"
+import { loadEnvLlmDefault } from "@/lib/env-llm-defaults"
 import type { WikiProject } from "@/types/wiki"
 
 function App() {
@@ -55,13 +56,20 @@ function App() {
           }
         }
 
+        const envLlmDefault = loadEnvLlmDefault()
         const savedConfig = await loadLlmConfig()
         if (savedConfig) {
           useWikiStore.getState().setLlmConfig(savedConfig)
+        } else if (envLlmDefault) {
+          useWikiStore.getState().setLlmConfig(envLlmDefault.config)
+          await saveLlmConfig(envLlmDefault.config)
         }
         const savedProviderConfigs = await loadProviderConfigs()
         if (savedProviderConfigs) {
           useWikiStore.getState().setProviderConfigs(savedProviderConfigs)
+        } else if (envLlmDefault) {
+          useWikiStore.getState().setProviderConfigs(envLlmDefault.providerConfigs)
+          await saveProviderConfigs(envLlmDefault.providerConfigs)
         }
         const savedActivePreset = await loadActivePresetId()
         if (savedActivePreset) {
@@ -81,6 +89,9 @@ function App() {
             useWikiStore.getState().setLlmConfig(resolved)
             await saveLlmConfig(resolved)
           }
+        } else if (envLlmDefault) {
+          useWikiStore.getState().setActivePresetId(envLlmDefault.activePresetId)
+          await saveActivePresetId(envLlmDefault.activePresetId)
         }
         const savedEmbeddingConfig = await loadEmbeddingConfig()
         if (savedEmbeddingConfig) {

--- a/src/components/chat/chat-message.tsx
+++ b/src/components/chat/chat-message.tsx
@@ -23,6 +23,7 @@ import { detectLanguage } from "@/lib/detect-language"
 import { getHtmlLang, getTextDirection } from "@/lib/language-metadata"
 import { MermaidDiagram, unwrapMermaidPre } from "@/components/mermaid-diagram"
 import { canContinueUnfinishedDeepChapter } from "./chat-resume"
+import { getCopyableAssistantContent } from "@/lib/chat-copy-content"
 
 interface ChatMessageProps {
   message: DisplayMessage
@@ -149,13 +150,7 @@ function CopyButton({ content }: { content: string }) {
   const [copied, setCopied] = useState(false)
 
   const handleCopy = useCallback(async () => {
-    // Strip HTML comments and thinking blocks before copying
-    const clean = content
-      .replace(/<!--.*?-->/gs, "")
-      .replace(/<think(?:ing)?>\s*[\s\S]*?<\/think(?:ing)?>\s*/gi, "")
-      .replace(/<think(?:ing)?>\s*[\s\S]*$/gi, "")
-      .trim()
-
+    const clean = getCopyableAssistantContent(content)
     await navigator.clipboard.writeText(clean)
     setCopied(true)
     setTimeout(() => setCopied(false), 2000)

--- a/src/components/chat/chat-panel.tsx
+++ b/src/components/chat/chat-panel.tsx
@@ -36,6 +36,7 @@ import {
   extractContinueUnfinishedDeepChapterContext,
   stripContinueUnfinishedDeepChapterContext,
 } from "./chat-resume"
+import { getCopyableAssistantContent } from "@/lib/chat-copy-content"
 
 function formatDate(timestamp: number): string {
   const d = new Date(timestamp)
@@ -210,7 +211,7 @@ export function ChatPanel() {
       await createDirectory(chapterDir)
       const chapterPath = `${chapterDir}/${fileName}`
       const chapterTitle = `第${nextNum}章`
-      const cleanedContent = cleanGeneratedChapterContentForSave(content)
+      const cleanedContent = cleanGeneratedChapterContentForSave(getCopyableAssistantContent(content))
 
       const now = new Date().toISOString().slice(0, 10)
       const frontmatter = [

--- a/src/lib/chat-copy-content.test.ts
+++ b/src/lib/chat-copy-content.test.ts
@@ -1,0 +1,25 @@
+import { expect, test } from "vitest"
+import { getCopyableAssistantContent } from "./chat-copy-content"
+
+test("copies generated chapter edit content instead of surrounding outline context", () => {
+  const content = [
+    "大纲：这里是检索到的大纲，不应该复制。",
+    "",
+    '<file_edit path="wiki/chapters/第3章.md">',
+    "<search>",
+    "旧章节。",
+    "</search>",
+    "<replace>",
+    "# 第3章",
+    "",
+    "宋惊蛰停在门口，第一次意识到自己没有退路。",
+    "</replace>",
+    "</file_edit>",
+  ].join("\n")
+
+  const copied = getCopyableAssistantContent(content)
+
+  expect(copied).toContain("宋惊蛰停在门口")
+  expect(copied).not.toContain("大纲")
+  expect(copied).not.toContain("<file_edit")
+})

--- a/src/lib/chat-copy-content.ts
+++ b/src/lib/chat-copy-content.ts
@@ -1,0 +1,29 @@
+import { parseAgentResponse } from "@/lib/novel/agent-parser"
+import { cleanGeneratedChapterContentForSave } from "@/lib/novel/chapter-content-cleanup"
+
+function stripHiddenAssistantBlocks(content: string): string {
+  return content
+    .replace(/<!--.*?-->/gs, "")
+    .replace(/<think(?:ing)?>\s*[\s\S]*?<\/think(?:ing)?>\s*/gi, "")
+    .replace(/<think(?:ing)?>\s*[\s\S]*$/gi, "")
+    .trim()
+}
+
+function isChapterEditPath(filePath: string): boolean {
+  const normalized = filePath.replace(/\\/g, "/").replace(/^\/+/, "").toLowerCase()
+  return normalized.startsWith("wiki/chapters/") && normalized.endsWith(".md")
+}
+
+export function getCopyableAssistantContent(content: string): string {
+  const parsed = parseAgentResponse(content)
+  const chapterEditReplacements = parsed.edits
+    .filter((edit) => isChapterEditPath(edit.filePath) && edit.replace.trim())
+    .map((edit) => cleanGeneratedChapterContentForSave(edit.replace).trim())
+    .filter(Boolean)
+
+  if (chapterEditReplacements.length > 0) {
+    return chapterEditReplacements.join("\n\n").trim()
+  }
+
+  return stripHiddenAssistantBlocks(parsed.textContent || content)
+}

--- a/src/lib/dashboard-issue-actions.test.ts
+++ b/src/lib/dashboard-issue-actions.test.ts
@@ -1,0 +1,14 @@
+import { expect, test } from "vitest"
+import { parseFactCheckInsertPlan } from "./dashboard-issue-actions"
+
+test("parses fact-check insert plan using the snake_case keys requested by the prompt", () => {
+  const plan = parseFactCheckInsertPlan(JSON.stringify({
+    anchor_text: "宋惊蛰走到楼梯口。",
+    insert_text: "他先确认身后的脚步声已经消失，才贴着墙面继续往前。",
+  }))
+
+  expect(plan).toEqual({
+    anchorText: "宋惊蛰走到楼梯口。",
+    insertText: "他先确认身后的脚步声已经消失，才贴着墙面继续往前。",
+  })
+})

--- a/src/lib/env-llm-defaults.ts
+++ b/src/lib/env-llm-defaults.ts
@@ -1,0 +1,49 @@
+import type { LlmConfig, ProviderConfigs } from "@/stores/wiki-store"
+
+const trimEnv = (value: unknown): string => {
+  return typeof value === "string" ? value.trim() : ""
+}
+
+const readContextSize = (): number => {
+  const raw = Number(trimEnv(import.meta.env.VITE_QMAI_LLM_CONTEXT_SIZE))
+  return Number.isFinite(raw) && raw > 0 ? raw : 204800
+}
+
+export function loadEnvLlmDefault(): {
+  config: LlmConfig
+  providerConfigs: ProviderConfigs
+  activePresetId: string
+} | null {
+  const apiKey = trimEnv(import.meta.env.VITE_QMAI_LLM_API_KEY)
+  const customEndpoint = trimEnv(import.meta.env.VITE_QMAI_LLM_ENDPOINT)
+  const model = trimEnv(import.meta.env.VITE_QMAI_LLM_MODEL)
+
+  if (!apiKey || !customEndpoint || !model) return null
+
+  const maxContextSize = readContextSize()
+  const config: LlmConfig = {
+    provider: "custom",
+    apiKey,
+    model,
+    ollamaUrl: "http://localhost:11434",
+    customEndpoint,
+    maxContextSize,
+    apiMode: "chat_completions",
+    reasoning: { mode: "auto" },
+  }
+
+  return {
+    config,
+    providerConfigs: {
+      custom: {
+        apiKey,
+        model,
+        baseUrl: customEndpoint,
+        apiMode: "chat_completions",
+        maxContextSize,
+        reasoning: { mode: "auto" },
+      },
+    },
+    activePresetId: "custom",
+  }
+}

--- a/src/lib/graph-relevance.spec.ts
+++ b/src/lib/graph-relevance.spec.ts
@@ -1,0 +1,79 @@
+import { beforeEach, expect, test, vi } from "vitest"
+import type { FileNode } from "@/types/wiki"
+
+vi.mock("@/commands/fs", () => ({
+  listDirectory: vi.fn(),
+  readFile: vi.fn(),
+}))
+
+import { listDirectory, readFile } from "@/commands/fs"
+import { buildRetrievalGraph, clearGraphCache } from "./graph-relevance"
+
+const mockedListDirectory = vi.mocked(listDirectory)
+const mockedReadFile = vi.mocked(readFile)
+
+function wikiTree(projectPath: string): FileNode[] {
+  return [
+    {
+      name: "entities",
+      path: `${projectPath}/wiki/entities`,
+      is_dir: true,
+      children: [
+        {
+          name: "A.md",
+          path: `${projectPath}/wiki/entities/A.md`,
+          is_dir: false,
+        },
+        {
+          name: "B.md",
+          path: `${projectPath}/wiki/entities/B.md`,
+          is_dir: false,
+        },
+      ],
+    },
+  ]
+}
+
+beforeEach(() => {
+  clearGraphCache()
+  vi.clearAllMocks()
+})
+
+test("shares in-flight graph builds for the same project and data version", async () => {
+  mockedListDirectory.mockResolvedValue(wikiTree("/Project"))
+  mockedReadFile.mockImplementation(async (path) => {
+    if (path.endsWith("A.md")) {
+      return "---\ntype: entity\ntitle: Alpha\n---\n\n# Alpha\n[[B]]"
+    }
+    return "---\ntype: entity\ntitle: Beta\n---\n\n# Beta\n"
+  })
+
+  const [first, second] = await Promise.all([
+    buildRetrievalGraph("/Project", 12),
+    buildRetrievalGraph("/Project", 12),
+  ])
+
+  expect(first).toBe(second)
+  expect(mockedListDirectory).toHaveBeenCalledTimes(1)
+  expect(mockedReadFile).toHaveBeenCalledTimes(2)
+})
+
+test("does not reuse graph cache across projects with the same data version", async () => {
+  mockedListDirectory.mockImplementation(async (wikiRoot) => {
+    const projectPath = String(wikiRoot).replace(/\/wiki$/, "")
+    return wikiTree(projectPath)
+  })
+  mockedReadFile.mockImplementation(async (path) => {
+    if (String(path).startsWith("/ProjectA/")) {
+      return "---\ntype: entity\ntitle: Project A Node\n---\n\n# Project A Node\n"
+    }
+    return "---\ntype: entity\ntitle: Project B Node\n---\n\n# Project B Node\n"
+  })
+
+  const first = await buildRetrievalGraph("/ProjectA", 12)
+  const second = await buildRetrievalGraph("/ProjectB", 12)
+
+  expect([...first.nodes.values()][0]?.title).toBe("Project A Node")
+  expect([...second.nodes.values()][0]?.title).toBe("Project B Node")
+  expect(mockedListDirectory).toHaveBeenCalledTimes(2)
+})

--- a/src/lib/graph-relevance.ts
+++ b/src/lib/graph-relevance.ts
@@ -46,7 +46,8 @@ const TYPE_AFFINITY: Record<string, Record<string, number>> = {
 // Module-level cache
 // ---------------------------------------------------------------------------
 
-let cachedGraph: RetrievalGraph | null = null
+const cachedGraphs = new Map<string, RetrievalGraph>()
+const inFlightGraphBuilds = new Map<string, Promise<RetrievalGraph>>()
 
 // ---------------------------------------------------------------------------
 // Helpers (pure)
@@ -158,18 +159,40 @@ export async function buildRetrievalGraph(
   projectPath: string,
   dataVersion: number = 0,
 ): Promise<RetrievalGraph> {
-  // Return cached if version matches
-  if (cachedGraph !== null && cachedGraph.dataVersion === dataVersion) {
+  const pp = normalizePath(projectPath)
+  const cacheKey = `${pp}::${dataVersion}`
+  const cachedGraph = cachedGraphs.get(cacheKey)
+  if (cachedGraph) {
     return cachedGraph
   }
 
-  const wikiRoot = `${normalizePath(projectPath)}/wiki`
+  const inFlight = inFlightGraphBuilds.get(cacheKey)
+  if (inFlight) {
+    return inFlight
+  }
+
+  const buildPromise = buildRetrievalGraphUncached(pp, dataVersion)
+  inFlightGraphBuilds.set(cacheKey, buildPromise)
+
+  try {
+    const graph = await buildPromise
+    cachedGraphs.set(cacheKey, graph)
+    return graph
+  } finally {
+    inFlightGraphBuilds.delete(cacheKey)
+  }
+}
+
+async function buildRetrievalGraphUncached(
+  normalizedProjectPath: string,
+  dataVersion: number,
+): Promise<RetrievalGraph> {
+  const wikiRoot = `${normalizedProjectPath}/wiki`
   let tree: FileNode[]
   try {
     tree = await listDirectory(wikiRoot)
   } catch {
     const emptyGraph: RetrievalGraph = { nodes: new Map(), dataVersion }
-    cachedGraph = emptyGraph
     return emptyGraph
   }
 
@@ -245,7 +268,6 @@ export async function buildRetrievalGraph(
   }
 
   const graph: RetrievalGraph = { nodes, dataVersion }
-  cachedGraph = graph
   return graph
 }
 
@@ -313,5 +335,6 @@ export function getRelatedNodes(
 }
 
 export function clearGraphCache(): void {
-  cachedGraph = null
+  cachedGraphs.clear()
+  inFlightGraphBuilds.clear()
 }

--- a/src/lib/graph-relevance.ts
+++ b/src/lib/graph-relevance.ts
@@ -26,6 +26,7 @@ export interface RetrievalGraph {
 // ---------------------------------------------------------------------------
 
 const WIKILINK_REGEX = /\[\[([^\]|]+?)(?:\|[^\]]+?)?\]\]/g
+const GRAPH_CONTENT_SCAN_LIMIT_CHARS = 50000
 
 const WEIGHTS = {
   directLink: 3.0,
@@ -218,7 +219,8 @@ async function buildRetrievalGraphUncached(
       continue
     }
 
-    const fm = extractFrontmatter(content)
+    const scanContent = limitGraphScanContent(content)
+    const fm = extractFrontmatter(scanContent)
     if (fm.isHistorical) {
       continue
     }
@@ -228,7 +230,7 @@ async function buildRetrievalGraphUncached(
       type: fm.type,
       path: file.path,
       sources: fm.sources,
-      rawLinks: extractWikilinks(content),
+      rawLinks: extractWikilinks(scanContent),
       fileName: file.name,
     })
   }
@@ -269,6 +271,11 @@ async function buildRetrievalGraphUncached(
 
   const graph: RetrievalGraph = { nodes, dataVersion }
   return graph
+}
+
+function limitGraphScanContent(content: string): string {
+  if (content.length <= GRAPH_CONTENT_SCAN_LIMIT_CHARS) return content
+  return content.slice(0, GRAPH_CONTENT_SCAN_LIMIT_CHARS)
 }
 
 export function calculateRelevance(

--- a/src/lib/novel/context-engine-search.spec.ts
+++ b/src/lib/novel/context-engine-search.spec.ts
@@ -1,0 +1,82 @@
+import { beforeEach, expect, test, vi } from "vitest"
+import { useWikiStore, DEFAULT_NOVEL_CONFIG } from "@/stores/wiki-store"
+
+vi.mock("@/commands/fs", () => ({
+  listDirectory: vi.fn(async () => []),
+  readFile: vi.fn(async () => {
+    throw new Error("missing")
+  }),
+}))
+
+vi.mock("@/lib/search", () => ({
+  searchWiki: vi.fn(async () => []),
+  tokenizeQuery: (query: string) => query.split(/[\s,，。！？、]+/).filter(Boolean),
+}))
+
+vi.mock("@/lib/rerank", () => ({
+  rerankCandidates: vi.fn(async (_query: string, candidates: unknown[]) => candidates),
+}))
+
+vi.mock("./search-adapter", () => ({
+  isAuthoritativeGenerationPath: vi.fn(() => true),
+  isHistoricalProjectionSnippet: vi.fn(() => false),
+  novelMixedSearch: vi.fn(async () => []),
+}))
+
+vi.mock("./chapter-ingest", () => ({
+  listSnapshots: vi.fn(async () => []),
+  loadSnapshot: vi.fn(async () => null),
+}))
+
+vi.mock("./revision-feedback", () => ({
+  buildRevisionDirectives: vi.fn(() => ""),
+  loadRevisionFeedbackForContext: vi.fn(async () => []),
+}))
+
+vi.mock("./character-cognition", () => ({
+  cognitionToContextText: vi.fn(() => ""),
+  loadCognitionState: vi.fn(async () => null),
+}))
+
+vi.mock("./volume", () => ({
+  getChapterVolumes: vi.fn(async () => []),
+}))
+
+vi.mock("./character-aura", () => ({
+  buildCharacterAuraContext: vi.fn(async () => ""),
+}))
+
+vi.mock("./soul-doc", () => ({
+  readSoulDoc: vi.fn(async () => ""),
+}))
+
+import { buildContextPack } from "./context-engine"
+import { novelMixedSearch } from "./search-adapter"
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  useWikiStore.setState({
+    novelMode: true,
+    novelConfig: {
+      ...DEFAULT_NOVEL_CONFIG,
+      recentSummaryWindow: 1,
+      searchTopK: 3,
+    },
+    revisionFeedbackWindowConfig: {
+      currentChapterIncludeShouldImprove: true,
+      previousChapterCarryEnabled: true,
+      lookbackChapterCount: 1,
+      lookbackIncludeMustFixOnly: true,
+    },
+  })
+})
+
+test("context mixed search leaves graph search to the dedicated graph context branch", async () => {
+  await buildContextPack("/Project", "审核第2章", 2)
+
+  expect(novelMixedSearch).toHaveBeenCalledWith(expect.objectContaining({
+    includeGraph: false,
+    includeKeyword: true,
+    includeVector: true,
+  }))
+})

--- a/src/lib/novel/context-engine-search.spec.ts
+++ b/src/lib/novel/context-engine-search.spec.ts
@@ -17,6 +17,11 @@ vi.mock("@/lib/rerank", () => ({
   rerankCandidates: vi.fn(async (_query: string, candidates: unknown[]) => candidates),
 }))
 
+vi.mock("@/lib/graph-relevance", () => ({
+  buildRetrievalGraph: vi.fn(async () => ({ nodes: new Map() })),
+  getRelatedNodes: vi.fn(() => []),
+}))
+
 vi.mock("./search-adapter", () => ({
   isAuthoritativeGenerationPath: vi.fn(() => true),
   isHistoricalProjectionSnippet: vi.fn(() => false),
@@ -51,7 +56,8 @@ vi.mock("./soul-doc", () => ({
 }))
 
 import { searchWiki } from "@/lib/search"
-import { buildContextPack } from "./context-engine"
+import { buildRetrievalGraph } from "@/lib/graph-relevance"
+import { buildContextPack, REVIEW_CONTEXT_OPTIONS } from "./context-engine"
 import { novelMixedSearch } from "./search-adapter"
 
 beforeEach(() => {
@@ -80,6 +86,18 @@ test("context mixed search leaves graph search to the dedicated graph context br
     includeKeyword: true,
     includeVector: true,
   }))
+})
+
+test("review context skips vector and graph retrieval before model review", async () => {
+  await buildContextPack("/Project", "审核第2章", 2, REVIEW_CONTEXT_OPTIONS)
+
+  expect(novelMixedSearch).toHaveBeenCalledWith(expect.objectContaining({
+    includeGraph: false,
+    includeKeyword: true,
+    includeVector: false,
+    topK: 6,
+  }))
+  expect(buildRetrievalGraph).not.toHaveBeenCalled()
 })
 
 test("context searchWiki calls disable vector search during review context assembly", async () => {

--- a/src/lib/novel/context-engine-search.spec.ts
+++ b/src/lib/novel/context-engine-search.spec.ts
@@ -50,6 +50,7 @@ vi.mock("./soul-doc", () => ({
   readSoulDoc: vi.fn(async () => ""),
 }))
 
+import { searchWiki } from "@/lib/search"
 import { buildContextPack } from "./context-engine"
 import { novelMixedSearch } from "./search-adapter"
 
@@ -79,4 +80,14 @@ test("context mixed search leaves graph search to the dedicated graph context br
     includeKeyword: true,
     includeVector: true,
   }))
+})
+
+test("context searchWiki calls disable vector search during review context assembly", async () => {
+  await buildContextPack("/Project", "审核第2章", 2)
+
+  const calls = vi.mocked(searchWiki).mock.calls
+  expect(calls.length).toBeGreaterThan(0)
+  for (const [, , options] of calls) {
+    expect(options).toEqual(expect.objectContaining({ includeVector: false }))
+  }
 })

--- a/src/lib/novel/context-engine.ts
+++ b/src/lib/novel/context-engine.ts
@@ -679,7 +679,7 @@ async function searchRelevantContentUnified(
       authoritativeOnly: true,
       includeKeyword: true,
       includeVector: true,
-      includeGraph: true,
+      includeGraph: false,
       includeRecentChapters: true,
       includeCanon: true,
     }).catch(() => []),

--- a/src/lib/novel/context-engine.ts
+++ b/src/lib/novel/context-engine.ts
@@ -1,6 +1,6 @@
 import { listDirectory, readFile } from "@/commands/fs"
 import i18n from "@/i18n"
-import { searchWiki, tokenizeQuery } from "@/lib/search"
+import { searchWiki, tokenizeQuery, type SearchWikiOptions } from "@/lib/search"
 import { normalizePath } from "@/lib/path-utils"
 import { useWikiStore } from "@/stores/wiki-store"
 import { parseChapterMeta } from "./chapter-meta"
@@ -34,6 +34,8 @@ const SECTION_PRIORITY: Record<string, number> = {
   "下一章推进建议": 16,
   "写作风格": 17,
 }
+const CONTEXT_SEARCH_MAX_CONTENT_CHARS = 20000
+const CONTEXT_SEARCH_DEFAULT_TOP_K = 8
 
 export interface ContextPack {
   task: string
@@ -285,9 +287,22 @@ function emptyPack(task: string): ContextPack {
   }
 }
 
+function contextSearchWiki(
+  pp: string,
+  query: string,
+  options: SearchWikiOptions = {},
+) {
+  return searchWiki(pp, query, {
+    ...options,
+    includeVector: false,
+    maxContentChars: options.maxContentChars ?? CONTEXT_SEARCH_MAX_CONTENT_CHARS,
+    topK: options.topK ?? CONTEXT_SEARCH_DEFAULT_TOP_K,
+  })
+}
+
 async function readOutlineContent(pp: string): Promise<string> {
   try {
-    const results = await searchWiki(pp, "outline type:outline")
+    const results = await contextSearchWiki(pp, "outline type:outline", { topK: 12 })
     if (results.length > 0) {
       const contents = await Promise.all(
         results.slice(0, 12).map(async (result) => {
@@ -399,7 +414,7 @@ async function readChapterOutlineContent(pp: string, chapterNumber?: number): Pr
   ]
   for (const query of queries) {
     try {
-      const results = await searchWiki(pp, query)
+      const results = await contextSearchWiki(pp, query, { topK: 1 })
       if (results.length > 0) {
         return (await readFile(results[0].path)).slice(0, 3000)
       }
@@ -472,7 +487,7 @@ async function readSnapshotContext(
 async function readRecentChapterSummaries(pp: string, count: number): Promise<string[]> {
   const summaries: string[] = []
   try {
-    const results = await searchWiki(pp, "type:chapter")
+    const results = await contextSearchWiki(pp, "type:chapter", { topK: count })
     for (const r of results.slice(0, count)) {
       try {
         const content = await readFile(r.path)
@@ -493,7 +508,7 @@ async function readRecentChapterSummaries(pp: string, count: number): Promise<st
 async function readPreviousChapterEnding(pp: string, chapterNumber?: number): Promise<string> {
   if (!chapterNumber || chapterNumber <= 1) return ""
   try {
-    const results = await searchWiki(pp, `chapter_number:${chapterNumber - 1}`)
+    const results = await contextSearchWiki(pp, `chapter_number:${chapterNumber - 1}`, { topK: 1 })
     if (results.length > 0) {
       const content = await readFile(results[0].path)
       const lines = content.split("\n")
@@ -506,7 +521,7 @@ async function readPreviousChapterEnding(pp: string, chapterNumber?: number): Pr
 
 async function readCharacterStates(pp: string): Promise<string> {
   try {
-    const results = await searchWiki(pp, "type:entity character")
+    const results = await contextSearchWiki(pp, "type:entity character", { topK: 5 })
     if (results.length > 0) {
       const contents = await Promise.all(results.slice(0, 5).map(r => readFile(r.path).catch(() => "")))
       return contents.filter(Boolean).join("\n---\n").slice(0, 3000)
@@ -526,7 +541,7 @@ async function readCognitionStates(pp: string): Promise<string> {
 
 async function readForeshadowingStates(pp: string): Promise<string> {
   try {
-    const results = await searchWiki(pp, "伏笔 foreshadowing")
+    const results = await contextSearchWiki(pp, "伏笔 foreshadowing", { topK: 3 })
     if (results.length > 0) {
       const contents = await Promise.all(results.slice(0, 3).map(r => readFile(r.path).catch(() => "")))
       return contents.filter(Boolean).join("\n---\n").slice(0, 2000)
@@ -537,7 +552,7 @@ async function readForeshadowingStates(pp: string): Promise<string> {
 
 async function readTimeline(pp: string): Promise<string> {
   try {
-    const results = await searchWiki(pp, "timeline 时间线")
+    const results = await contextSearchWiki(pp, "timeline 时间线", { topK: 1 })
     if (results.length > 0) {
       const content = await readFile(results[0].path)
       return content.slice(0, 2000)
@@ -548,7 +563,7 @@ async function readTimeline(pp: string): Promise<string> {
 
 async function readRelatedSettings(pp: string): Promise<string> {
   try {
-    const results = await searchWiki(pp, "setting 设定 location 地点")
+    const results = await contextSearchWiki(pp, "setting 设定 location 地点", { topK: 3 })
     if (results.length > 0) {
       const contents = await Promise.all(results.slice(0, 3).map(r => readFile(r.path).catch(() => "")))
       return contents.filter(Boolean).join("\n---\n").slice(0, 2000)
@@ -559,7 +574,7 @@ async function readRelatedSettings(pp: string): Promise<string> {
 
 async function readCanonRules(pp: string): Promise<string> {
   try {
-    const results = await searchWiki(pp, "canon 正史 rule 规则")
+    const results = await contextSearchWiki(pp, "canon 正史 rule 规则", { topK: 1 })
     if (results.length > 0) {
       const content = await readFile(results[0].path)
       return content.slice(0, 2000)
@@ -570,7 +585,7 @@ async function readCanonRules(pp: string): Promise<string> {
 
 async function readWritingStyle(pp: string): Promise<string> {
   try {
-    const results = await searchWiki(pp, "style 风格 writing 写作")
+    const results = await contextSearchWiki(pp, "style 风格 writing 写作", { topK: 1 })
     if (results.length > 0) {
       const content = await readFile(results[0].path)
       return content.slice(0, 1000)
@@ -622,8 +637,8 @@ export async function searchRelevantContent(
   const query = queryParts.join(" ")
 
   const [keywordResults, indexResults, vectorResults] = await Promise.all([
-    searchWiki(pp, query).catch(() => []),
-    searchWiki(pp, `关键词索引 向量索引 ${task}`).catch(() => []),
+    contextSearchWiki(pp, query, { topK: limit }).catch(() => []),
+    contextSearchWiki(pp, `关键词索引 向量索引 ${task}`, { topK: limit }).catch(() => []),
     runVectorSearchForContext(pp, query, limit).catch(() => []),
   ])
 
@@ -683,7 +698,7 @@ async function searchRelevantContentUnified(
       includeRecentChapters: true,
       includeCanon: true,
     }).catch(() => []),
-    searchWiki(pp, `关键词索引 向量索引 ${task}`, {
+    contextSearchWiki(pp, `关键词索引 向量索引 ${task}`, {
       rerank: true,
       topK: Math.max(limit, 4),
       rerankPurpose: "用于补充剧情上下文中的索引和记忆条目。",

--- a/src/lib/novel/context-engine.ts
+++ b/src/lib/novel/context-engine.ts
@@ -36,6 +36,21 @@ const SECTION_PRIORITY: Record<string, number> = {
 }
 const CONTEXT_SEARCH_MAX_CONTENT_CHARS = 20000
 const CONTEXT_SEARCH_DEFAULT_TOP_K = 8
+const REVIEW_CONTEXT_MAX_TOP_K = 3
+
+export interface BuildContextPackOptions {
+  includeVectorSearch?: boolean
+  includeGraphSearch?: boolean
+  includeRerank?: boolean
+  maxSearchTopK?: number
+}
+
+export const REVIEW_CONTEXT_OPTIONS: BuildContextPackOptions = {
+  includeVectorSearch: false,
+  includeGraphSearch: false,
+  includeRerank: false,
+  maxSearchTopK: REVIEW_CONTEXT_MAX_TOP_K,
+}
 
 export interface ContextPack {
   task: string
@@ -64,6 +79,7 @@ export async function buildContextPack(
   projectPath: string,
   task: string,
   chapterNumber?: number,
+  options: BuildContextPackOptions = {},
 ): Promise<ContextPack> {
   const pp = normalizePath(projectPath)
   const novelMode = useWikiStore.getState().novelMode
@@ -74,7 +90,11 @@ export async function buildContextPack(
   }
 
   const recentSummaryWindow = novelConfig.recentSummaryWindow > 0 ? novelConfig.recentSummaryWindow : 8
-  const searchTopK = novelConfig.searchTopK > 0 ? novelConfig.searchTopK : 5
+  const configuredSearchTopK = novelConfig.searchTopK > 0 ? novelConfig.searchTopK : 5
+  const searchTopK = Math.max(
+    1,
+    Math.min(configuredSearchTopK, options.maxSearchTopK ?? configuredSearchTopK),
+  )
   const snapshotLookback = 3
 
   const resolvedChapterNumber = chapterNumber ?? extractChapterNumberFromTask(task)
@@ -91,8 +111,15 @@ export async function buildContextPack(
     readRelatedSettings(pp),
     readCanonRules(pp),
     readWritingStyle(pp),
-    searchRelevantContentUnified(pp, task, resolvedChapterNumber, searchTopK),
-    searchGraphRelevantContent(pp, task, resolvedChapterNumber),
+    searchRelevantContentUnified(pp, task, resolvedChapterNumber, searchTopK, {
+      includeVector: options.includeVectorSearch ?? true,
+      includeRerank: options.includeRerank ?? true,
+    }),
+    options.includeGraphSearch === false
+      ? Promise.resolve("")
+      : searchGraphRelevantContent(pp, task, resolvedChapterNumber, {
+        includeRerank: options.includeRerank ?? true,
+      }),
     loadRevisionFeedbackForContext(pp, resolvedChapterNumber, revisionFeedbackWindowConfig),
     readCognitionStates(pp),
     readSoulDoc(pp),
@@ -671,6 +698,10 @@ async function searchRelevantContentUnified(
   task: string,
   chapterNumber: number | undefined,
   limit: number,
+  options: {
+    includeVector?: boolean
+    includeRerank?: boolean
+  } = {},
 ): Promise<string> {
   const tokens = tokenizeQuery(task)
   const entityHints = tokens.filter((t) => t.length >= 2).slice(0, 5)
@@ -685,6 +716,8 @@ async function searchRelevantContentUnified(
   }
   const query = queryParts.join(" ")
 
+  const includeVector = options.includeVector ?? true
+  const includeRerank = options.includeRerank ?? true
   const [semanticResults, indexResults, vectorResults] = await Promise.all([
     novelMixedSearch({
       projectPath: pp,
@@ -693,17 +726,17 @@ async function searchRelevantContentUnified(
       topK: Math.max(limit * 2, 6),
       authoritativeOnly: true,
       includeKeyword: true,
-      includeVector: true,
+      includeVector,
       includeGraph: false,
       includeRecentChapters: true,
       includeCanon: true,
     }).catch(() => []),
     contextSearchWiki(pp, `关键词索引 向量索引 ${task}`, {
-      rerank: true,
+      rerank: includeRerank,
       topK: Math.max(limit, 4),
       rerankPurpose: "用于补充剧情上下文中的索引和记忆条目。",
     }).catch(() => []),
-    runVectorSearchForContext(pp, query, limit).catch(() => []),
+    includeVector ? runVectorSearchForContext(pp, query, limit).catch(() => []) : Promise.resolve([]),
   ])
 
   const candidates = [
@@ -737,10 +770,12 @@ async function searchRelevantContentUnified(
     return isAuthoritativeGenerationPath(path)
   })
 
-  const reranked = await rerankCandidates(query, candidates, {
-    topK: Math.max(limit * 2, limit),
-    purpose: "用于构建小说写作上下文，优先保留最能支撑当前章节任务的记忆、设定、伏笔和正史约束。",
-  }).catch(() => candidates)
+  const reranked = includeRerank
+    ? await rerankCandidates(query, candidates, {
+      topK: Math.max(limit * 2, limit),
+      purpose: "用于构建小说写作上下文，优先保留最能支撑当前章节任务的记忆、设定、伏笔和正史约束。",
+    }).catch(() => candidates)
+    : candidates.slice(0, Math.max(limit * 2, limit))
 
   const merged: string[] = []
   const seen = new Set<string>()
@@ -802,6 +837,7 @@ async function searchGraphRelevantContent(
   pp: string,
   task: string,
   _chapterNumber: number | undefined,
+  options: { includeRerank?: boolean } = {},
 ): Promise<string> {
   try {
     const { buildRetrievalGraph, getRelatedNodes } = await import("@/lib/graph-relevance")
@@ -856,20 +892,23 @@ async function searchGraphRelevantContent(
     }
 
     scoredNodes.sort((a, b) => b.relevance - a.relevance)
-    const topNodes = await rerankCandidates(
-      task,
-      scoredNodes.slice(0, 10).map((node, index) => ({
-        id: `graph:${index}:${node.title}`,
-        title: node.title,
-        snippet: node.snippet,
-        source: "graph_context",
-        relevance: node.relevance,
-      })),
-      {
-        topK: 10,
-        purpose: "用于补充图谱关联上下文，优先保留和当前任务最直接相关的关联节点。",
-      },
-    ).catch(() => scoredNodes.slice(0, 10))
+    const graphCandidates = scoredNodes.slice(0, 10)
+    const topNodes = options.includeRerank === false
+      ? graphCandidates
+      : await rerankCandidates(
+        task,
+        graphCandidates.map((node, index) => ({
+          id: `graph:${index}:${node.title}`,
+          title: node.title,
+          snippet: node.snippet,
+          source: "graph_context",
+          relevance: node.relevance,
+        })),
+        {
+          topK: 10,
+          purpose: "用于补充图谱关联上下文，优先保留和当前任务最直接相关的关联节点。",
+        },
+      ).catch(() => graphCandidates)
     if (topNodes.length === 0) return ""
 
     return topNodes.map(

--- a/src/lib/novel/dimension-review-adapter.spec.ts
+++ b/src/lib/novel/dimension-review-adapter.spec.ts
@@ -181,6 +181,43 @@ describe("six-dimension review adapter", () => {
     })
   })
 
+  it("coalesces high-frequency dimension thinking callbacks from streamed tokens", async () => {
+    streamChatMock.mockImplementation(async (
+      _config: LlmConfig,
+      messages: Array<{ role: string; content: string }>,
+      callbacks: StreamCallbacks,
+    ) => {
+      const prompt = messages.map((message) => message.content).join("\n")
+      if (prompt.includes("最终 JSON")) {
+        callbacks.onToken(JSON.stringify({
+          score: 90,
+          status: "pass",
+          summary: "爽感密度通过",
+          issues: [],
+        }))
+      } else {
+        for (let i = 0; i < 50; i += 1) {
+          callbacks.onToken(`阶段片段 ${i}`)
+        }
+      }
+      callbacks.onDone()
+    })
+
+    const thinking: string[] = []
+    await reviewChapterDimension({
+      llmConfig,
+      contextPack,
+      chapterContent: "主角直接说出族谱被换。",
+      dimension: SIX_REVIEW_DIMENSIONS.thrill,
+      callbacks: {
+        onThinking: (_dimensionKey, content) => thinking.push(content),
+      },
+    })
+
+    expect(thinking.length).toBeLessThan(20)
+    expect(thinking.join("\n")).toContain("阶段片段 49")
+  })
+
   it("runs all six dimensions with one shared context and continues after one failure", async () => {
     const finalCallDimensions: string[] = []
     streamChatMock.mockImplementation(async (

--- a/src/lib/novel/dimension-review-adapter.spec.ts
+++ b/src/lib/novel/dimension-review-adapter.spec.ts
@@ -75,6 +75,12 @@ vi.mock("./model-resolver", () => ({
 
 vi.mock("./context-engine", () => ({
   buildContextPack: mocks.buildContextPackMock,
+  REVIEW_CONTEXT_OPTIONS: {
+    includeVectorSearch: false,
+    includeGraphSearch: false,
+    includeRerank: false,
+    maxSearchTopK: 3,
+  },
   contextPackToPrompt: (pack: ContextPack) => [
     `当前任务：${pack.task}`,
     `章节目标：${pack.chapterGoal}`,
@@ -254,6 +260,16 @@ describe("six-dimension review adapter", () => {
     })
 
     expect(buildContextPackMock).toHaveBeenCalledTimes(1)
+    expect(buildContextPackMock).toHaveBeenCalledWith(
+      "E:/Novel",
+      "六维审查第8章",
+      8,
+      expect.objectContaining({
+        includeVectorSearch: false,
+        includeGraphSearch: false,
+        includeRerank: false,
+      }),
+    )
     expect(finalCallDimensions).toEqual(SIX_REVIEW_DIMENSION_ORDER)
     expect(Object.keys(results)).toEqual(SIX_REVIEW_DIMENSION_ORDER)
     expect(results.pacing?.status).toBe("error")

--- a/src/lib/novel/dimension-review-adapter.ts
+++ b/src/lib/novel/dimension-review-adapter.ts
@@ -6,6 +6,7 @@ import { buildContextPack, contextPackToPrompt, type ContextPack } from "./conte
 import { resolveNovelModel } from "./model-resolver"
 import { hasUsableLlm } from "@/lib/has-usable-llm"
 import type { NovelReviewResult } from "./review-adapter"
+import { createReviewThinkingPublisher } from "./review-thinking-publisher"
 
 export type SixReviewDimensionKey = "thrill" | "consistency" | "pacing" | "character" | "continuity" | "pull"
 export type DimensionReviewStatus = "error" | "high" | "medium" | "low" | "pass"
@@ -239,10 +240,15 @@ async function runDimensionStage(
     { role: "user", content: userPrompt },
   ]
   let result = ""
+  const thinkingPublisher = createReviewThinkingPublisher({
+    publish: (content) => {
+      callbacks.onThinking?.(dimension.key, formatDimensionThinking(dimension, content))
+    },
+  })
   const streamCallbacks: StreamCallbacks = {
     onToken: (token: string) => {
       result += token
-      callbacks.onThinking?.(dimension.key, formatDimensionThinking(dimension, result))
+      thinkingPublisher.publish(result)
     },
     onDone: () => {},
     onError: (error: Error) => {
@@ -250,13 +256,17 @@ async function runDimensionStage(
     },
   }
 
-  await streamChat(
-    llmConfig,
-    messages,
-    streamCallbacks,
-    AbortSignal.timeout(120000),
-    { reasoning: { mode: "high" } },
-  )
+  try {
+    await streamChat(
+      llmConfig,
+      messages,
+      streamCallbacks,
+      AbortSignal.timeout(120000),
+      { reasoning: { mode: "high" } },
+    )
+  } finally {
+    thinkingPublisher.flush()
+  }
   return result.trim()
 }
 

--- a/src/lib/novel/dimension-review-adapter.ts
+++ b/src/lib/novel/dimension-review-adapter.ts
@@ -2,7 +2,7 @@ import { streamChat, type StreamCallbacks } from "@/lib/llm-client"
 import type { ChatMessage } from "@/lib/llm-providers"
 import type { LlmConfig } from "@/stores/wiki-store"
 import { useWikiStore } from "@/stores/wiki-store"
-import { buildContextPack, contextPackToPrompt, type ContextPack } from "./context-engine"
+import { buildContextPack, contextPackToPrompt, REVIEW_CONTEXT_OPTIONS, type ContextPack } from "./context-engine"
 import { resolveNovelModel } from "./model-resolver"
 import { hasUsableLlm } from "@/lib/has-usable-llm"
 import type { NovelReviewResult } from "./review-adapter"
@@ -199,6 +199,7 @@ export async function runSixDimensionReview({
     projectPath,
     `六维审查第${chapterNumber || "?"}章`,
     chapterNumber,
+    REVIEW_CONTEXT_OPTIONS,
   )
 
   const results: Partial<Record<SixReviewDimensionKey, DimensionReviewResult>> = {}

--- a/src/lib/novel/review-adapter.spec.ts
+++ b/src/lib/novel/review-adapter.spec.ts
@@ -6,6 +6,7 @@ import { buildReviewPrompt, reviewChapter } from "./review-adapter"
 
 const mocks = vi.hoisted(() => ({
   streamChatMock: vi.fn(),
+  buildContextPackMock: vi.fn(),
   llmConfig: {
     provider: "custom" as const,
     apiKey: "test-key",
@@ -40,6 +41,7 @@ const mocks = vi.hoisted(() => ({
 }))
 
 const streamChatMock = mocks.streamChatMock
+const buildContextPackMock = mocks.buildContextPackMock
 const llmConfig = mocks.llmConfig as LlmConfig
 const contextPack = mocks.contextPack satisfies ContextPack
 
@@ -66,7 +68,13 @@ vi.mock("./model-resolver", () => ({
 }))
 
 vi.mock("./context-engine", () => ({
-  buildContextPack: vi.fn(async () => mocks.contextPack),
+  buildContextPack: mocks.buildContextPackMock,
+  REVIEW_CONTEXT_OPTIONS: {
+    includeVectorSearch: false,
+    includeGraphSearch: false,
+    includeRerank: false,
+    maxSearchTopK: 3,
+  },
   contextPackToPrompt: (pack: ContextPack) => [
     `当前任务：${pack.task}`,
     `当前章节目标：${pack.chapterGoal}`,
@@ -86,6 +94,8 @@ vi.mock("./context-engine", () => ({
 describe("review-adapter staged review", () => {
   beforeEach(() => {
     streamChatMock.mockReset()
+    buildContextPackMock.mockReset()
+    buildContextPackMock.mockResolvedValue(contextPack)
     llmConfig.reasoning = { mode: "auto" }
   })
 
@@ -136,6 +146,16 @@ describe("review-adapter staged review", () => {
     )
 
     expect(streamChatMock).toHaveBeenCalledTimes(4)
+    expect(buildContextPackMock).toHaveBeenCalledWith(
+      "E:/Novel",
+      "审稿第8章",
+      8,
+      expect.objectContaining({
+        includeVectorSearch: false,
+        includeGraphSearch: false,
+        includeRerank: false,
+      }),
+    )
     expect(streamChatMock.mock.calls.every((call) => call[4]?.reasoning?.mode === "high")).toBe(true)
     expect(thinking.join("\n")).toContain("阶段1：审查任务识别")
     expect(thinking.join("\n")).toContain("阶段4：事实与记忆核对")

--- a/src/lib/novel/review-adapter.spec.ts
+++ b/src/lib/novel/review-adapter.spec.ts
@@ -152,4 +152,34 @@ describe("review-adapter staged review", () => {
       suggestion: "改为通过族谱缺页和行为细节推断异常。",
     }])
   })
+
+  it("coalesces high-frequency staged thinking callbacks from streamed tokens", async () => {
+    let callCount = 0
+    streamChatMock.mockImplementation(async (
+      _config: LlmConfig,
+      _messages: Array<{ role: string; content: string }>,
+      callbacks: StreamCallbacks,
+    ) => {
+      callCount += 1
+      if (callCount === 4) {
+        callbacks.onToken("[]")
+      } else {
+        for (let i = 0; i < 50; i += 1) {
+          callbacks.onToken(`阶段片段 ${i}`)
+        }
+      }
+      callbacks.onDone()
+    })
+
+    const thinking: string[] = []
+    await reviewChapter(
+      "E:/Novel",
+      "主角直接说出族谱被换。",
+      8,
+      { onThinking: (content) => thinking.push(content) },
+    )
+
+    expect(thinking.length).toBeLessThan(20)
+    expect(thinking.join("\n")).toContain("阶段片段 49")
+  })
 })

--- a/src/lib/novel/review-adapter.ts
+++ b/src/lib/novel/review-adapter.ts
@@ -3,7 +3,7 @@ import i18n from "@/i18n"
 import type { ChatMessage } from "@/lib/llm-providers"
 import { useWikiStore } from "@/stores/wiki-store"
 import { getOutputLanguage, buildLanguageReminder } from "@/lib/output-language"
-import { contextPackToPrompt, buildContextPack, type ContextPack } from "./context-engine"
+import { contextPackToPrompt, buildContextPack, REVIEW_CONTEXT_OPTIONS, type ContextPack } from "./context-engine"
 import { resolveNovelModel } from "./model-resolver"
 import { hasUsableLlm } from "@/lib/has-usable-llm"
 import { createReviewThinkingPublisher } from "./review-thinking-publisher"
@@ -112,6 +112,7 @@ export async function reviewChapter(
     projectPath,
     `审稿第${chapterNumber || "?"}章`,
     chapterNumber,
+    REVIEW_CONTEXT_OPTIONS,
   )
 
   const outputLang = getOutputLanguage()

--- a/src/lib/novel/review-adapter.ts
+++ b/src/lib/novel/review-adapter.ts
@@ -6,6 +6,7 @@ import { getOutputLanguage, buildLanguageReminder } from "@/lib/output-language"
 import { contextPackToPrompt, buildContextPack, type ContextPack } from "./context-engine"
 import { resolveNovelModel } from "./model-resolver"
 import { hasUsableLlm } from "@/lib/has-usable-llm"
+import { createReviewThinkingPublisher } from "./review-thinking-publisher"
 
 export interface NovelReviewResult {
   severity: "error" | "warning" | "info"
@@ -219,10 +220,15 @@ async function runReviewStage(
   ]
 
   let result = ""
+  const thinkingPublisher = createReviewThinkingPublisher({
+    publish: (content) => {
+      publishReviewStageThinking(stageThinking, callbacks, stageTitle, content)
+    },
+  })
   const streamCallbacks: StreamCallbacks = {
     onToken: (token: string) => {
       result += token
-      publishReviewStageThinking(stageThinking, callbacks, stageTitle, result)
+      thinkingPublisher.publish(result)
     },
     onDone: () => {},
     onError: (error: Error) => {
@@ -230,13 +236,17 @@ async function runReviewStage(
     },
   }
 
-  await streamChat(
-    llmConfig,
-    messages,
-    streamCallbacks,
-    AbortSignal.timeout(120000),
-    { reasoning: { mode: "high" } },
-  )
+  try {
+    await streamChat(
+      llmConfig,
+      messages,
+      streamCallbacks,
+      AbortSignal.timeout(120000),
+      { reasoning: { mode: "high" } },
+    )
+  } finally {
+    thinkingPublisher.flush()
+  }
 
   return result.trim()
 }

--- a/src/lib/novel/review-thinking-publisher.ts
+++ b/src/lib/novel/review-thinking-publisher.ts
@@ -1,0 +1,56 @@
+const REVIEW_THINKING_UPDATE_INTERVAL_MS = 300
+const REVIEW_THINKING_MAX_CHARS = 12000
+
+interface ReviewThinkingPublisherOptions {
+  publish: (thinking: string) => void
+  minIntervalMs?: number
+  maxChars?: number
+  now?: () => number
+}
+
+export interface ReviewThinkingPublisher {
+  publish: (thinking: string) => void
+  flush: () => void
+}
+
+export function createReviewThinkingPublisher({
+  publish,
+  minIntervalMs = REVIEW_THINKING_UPDATE_INTERVAL_MS,
+  maxChars = REVIEW_THINKING_MAX_CHARS,
+  now = () => Date.now(),
+}: ReviewThinkingPublisherOptions): ReviewThinkingPublisher {
+  let latestThinking: string | null = null
+  let lastPublishedThinking = ""
+  let lastPublishedAt: number | null = null
+
+  const publishLatest = (force: boolean) => {
+    if (latestThinking === null) return
+    const currentTime = now()
+    if (!force && lastPublishedAt !== null && currentTime - lastPublishedAt < minIntervalMs) {
+      return
+    }
+    if (latestThinking === lastPublishedThinking) return
+
+    lastPublishedAt = currentTime
+    lastPublishedThinking = latestThinking
+    publish(latestThinking)
+  }
+
+  return {
+    publish: (thinking: string) => {
+      latestThinking = truncateReviewThinking(thinking, maxChars)
+      publishLatest(false)
+    },
+    flush: () => {
+      publishLatest(true)
+    },
+  }
+}
+
+export function truncateReviewThinking(thinking: string, maxChars = REVIEW_THINKING_MAX_CHARS): string {
+  if (thinking.length <= maxChars) return thinking
+  return [
+    `[前方 ${thinking.length - maxChars} 字审阅过程已折叠，避免页面卡顿]`,
+    thinking.slice(-maxChars),
+  ].join("\n")
+}

--- a/src/lib/novel/search-adapter.spec.ts
+++ b/src/lib/novel/search-adapter.spec.ts
@@ -1,0 +1,41 @@
+import { beforeEach, expect, test, vi } from "vitest"
+
+vi.mock("@/lib/search", () => ({
+  searchWiki: vi.fn(async () => []),
+}))
+
+vi.mock("@/commands/fs", () => ({
+  readFile: vi.fn(async () => {
+    throw new Error("missing")
+  }),
+}))
+
+vi.mock("@/lib/rerank", () => ({
+  rerankCandidates: vi.fn(async (_query: string, candidates: unknown[]) => candidates),
+}))
+
+import { searchWiki } from "@/lib/search"
+import { novelMixedSearch } from "./search-adapter"
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+test("keyword branch disables searchWiki vector pass when mixed search has its own vector branch", async () => {
+  await novelMixedSearch({
+    projectPath: "/Project",
+    query: "第4章 审稿",
+    topK: 5,
+    includeKeyword: true,
+    includeVector: true,
+    includeGraph: false,
+    includeRecentChapters: false,
+    includeCanon: false,
+  })
+
+  expect(searchWiki).toHaveBeenCalledWith(
+    "/Project",
+    "第4章 审稿",
+    expect.objectContaining({ includeVector: false }),
+  )
+})

--- a/src/lib/novel/search-adapter.ts
+++ b/src/lib/novel/search-adapter.ts
@@ -47,6 +47,7 @@ const SOURCE_TIE_PRIORITY: Record<NovelSearchResult["type"], number> = {
   canon: 3,
   recent_chapter: 4,
 }
+const KEYWORD_SEARCH_MAX_CONTENT_CHARS = 30000
 
 export function isAuthoritativeGenerationPath(path: string): boolean {
   return /\/wiki\/(entities|concepts|memory|chapters)\//.test(path)
@@ -67,7 +68,11 @@ export async function novelMixedSearch(params: NovelSearchParams): Promise<Novel
   const promises: Promise<void>[] = []
 
   if (params.includeKeyword !== false) {
-    const pKeyword = runSearchBranch("keyword", searchWiki(pp, params.query)).then(items => {
+    const pKeyword = runSearchBranch("keyword", searchWiki(pp, params.query, {
+      includeVector: false,
+      maxContentChars: KEYWORD_SEARCH_MAX_CONTENT_CHARS,
+      topK: Math.max(topK * 2, 10),
+    })).then(items => {
       console.log("[novelMixedSearch] keyword done, got", items.length)
       results.push(...items.slice(0, topK).map((item, sourceRank) => ({
         type: "keyword" as const,

--- a/src/lib/novel/start-review-run.spec.ts
+++ b/src/lib/novel/start-review-run.spec.ts
@@ -55,4 +55,40 @@ describe("startNovelReviewRun", () => {
 
     expect(useWikiStore.getState().reviewRun?.thinking).toContain("阶段1：审查任务识别")
   })
+
+  it("coalesces high-frequency review thinking updates before writing to the store", async () => {
+    let thinkingUpdateCount = 0
+    const unsubscribe = useWikiStore.subscribe((state, previousState) => {
+      if (state.reviewRun?.thinking && state.reviewRun.thinking !== previousState.reviewRun?.thinking) {
+        thinkingUpdateCount += 1
+      }
+    })
+
+    mocks.reviewChapter.mockImplementation(async (
+      _projectPath: string,
+      _fileContent: string,
+      _chapterNumber: number | undefined,
+      callbacks: { onThinking?: (content: string) => void },
+    ) => {
+      callbacks.onThinking?.("## 阶段1：审查任务识别\n开始")
+      for (let i = 0; i < 50; i += 1) {
+        callbacks.onThinking?.(`## 阶段1：审查任务识别\n流式片段 ${i}`)
+      }
+      return []
+    })
+
+    try {
+      await startNovelReviewRun({
+        fileContent: "---\nchapterNumber: 8\n---\n正文",
+        projectPath: "E:/Novel",
+        selectedFile: "E:/Novel/wiki/chapters/008.md",
+        t: ((key: string) => key) as never,
+      })
+    } finally {
+      unsubscribe()
+    }
+
+    expect(thinkingUpdateCount).toBeLessThanOrEqual(3)
+    expect(useWikiStore.getState().reviewRun?.thinking).toContain("流式片段 49")
+  })
 })

--- a/src/lib/novel/start-review-run.test.ts
+++ b/src/lib/novel/start-review-run.test.ts
@@ -1,0 +1,20 @@
+import { expect, test } from "vitest"
+import { resolveReviewChapterTarget } from "./start-review-run"
+
+test("prefers the selected chapter file name over stale chapter frontmatter", () => {
+  const content = [
+    "---",
+    "type: chapter",
+    "chapter_number: 3",
+    'title: "第3章"',
+    "---",
+    "",
+    "# 第2章",
+    "",
+    "正文。",
+  ].join("\n")
+
+  const target = resolveReviewChapterTarget(content, "/project/wiki/chapters/第2章.md")
+
+  expect(target.chapterNumber).toBe(2)
+})

--- a/src/lib/novel/start-review-run.ts
+++ b/src/lib/novel/start-review-run.ts
@@ -6,6 +6,7 @@ import { persistRevisionFeedbackForChapter, pickRevisionFeedbackFromReviewResult
 import { saveGenerationHistoryEntry } from "@/lib/novel/generation-history"
 import { getFileStem } from "@/lib/path-utils"
 import { useWikiStore } from "@/stores/wiki-store"
+import { createReviewThinkingPublisher } from "./review-thinking-publisher"
 
 interface StartNovelReviewRunArgs {
   fileContent: string
@@ -55,13 +56,19 @@ export async function startNovelReviewRun({
   const target = resolveReviewChapterTarget(fileContent, selectedFile)
   const runId = `${Date.now()}-${Math.random()}`
   useWikiStore.getState().setReviewRun({ runId, projectPath, filePath: selectedFile, running: true, results: [] })
+  const thinkingPublisher = createReviewThinkingPublisher({
+    publish: (thinking) => {
+      useWikiStore.getState().finishReviewRun(runId, { running: true, thinking })
+    },
+  })
 
   try {
     const results = await reviewChapter(projectPath, fileContent, target.chapterNumber, {
       onThinking: (thinking) => {
-        useWikiStore.getState().finishReviewRun(runId, { running: true, thinking })
+        thinkingPublisher.publish(thinking)
       },
     })
+    thinkingPublisher.flush()
     useWikiStore.getState().finishReviewRun(runId, { running: true, results, error: undefined })
     await saveGenerationHistoryEntry(projectPath, {
       kind: "review",
@@ -82,8 +89,10 @@ export async function startNovelReviewRun({
     }
   } catch (error) {
     console.error("审查失败:", error)
+    thinkingPublisher.flush()
     useWikiStore.getState().finishReviewRun(runId, { running: false, error: t("novel.review.runFailed") })
   } finally {
+    thinkingPublisher.flush()
     const current = useWikiStore.getState().reviewRun
     if (current?.runId === runId) {
       useWikiStore.getState().finishReviewRun(runId, { running: false, results: current.results })

--- a/src/lib/novel/start-review-run.ts
+++ b/src/lib/novel/start-review-run.ts
@@ -7,6 +7,7 @@ import { saveGenerationHistoryEntry } from "@/lib/novel/generation-history"
 import { getFileStem } from "@/lib/path-utils"
 import { useWikiStore } from "@/stores/wiki-store"
 import { createReviewThinkingPublisher } from "./review-thinking-publisher"
+import { yieldToBrowserFrame } from "./yield-to-browser"
 
 interface StartNovelReviewRunArgs {
   fileContent: string
@@ -56,6 +57,7 @@ export async function startNovelReviewRun({
   const target = resolveReviewChapterTarget(fileContent, selectedFile)
   const runId = `${Date.now()}-${Math.random()}`
   useWikiStore.getState().setReviewRun({ runId, projectPath, filePath: selectedFile, running: true, results: [] })
+  await yieldToBrowserFrame()
   const thinkingPublisher = createReviewThinkingPublisher({
     publish: (thinking) => {
       useWikiStore.getState().finishReviewRun(runId, { running: true, thinking })

--- a/src/lib/novel/start-review-run.ts
+++ b/src/lib/novel/start-review-run.ts
@@ -4,6 +4,7 @@ import { parseChapterMeta } from "@/lib/novel/chapter-meta"
 import { reviewChapter } from "@/lib/novel/review-adapter"
 import { persistRevisionFeedbackForChapter, pickRevisionFeedbackFromReviewResults } from "@/lib/novel/revision-feedback"
 import { saveGenerationHistoryEntry } from "@/lib/novel/generation-history"
+import { getFileStem } from "@/lib/path-utils"
 import { useWikiStore } from "@/stores/wiki-store"
 
 interface StartNovelReviewRunArgs {
@@ -12,6 +13,34 @@ interface StartNovelReviewRunArgs {
   selectedFile: string
   t: TFunction
   onHistorySaved?: () => Promise<void> | void
+}
+
+export interface ReviewChapterTarget {
+  chapterNumber?: number
+}
+
+function parseChapterNumberFromSelectedFile(selectedFile: string): number | undefined {
+  const stem = getFileStem(selectedFile).trim()
+  const chineseChapter = stem.match(/第\s*0*(\d+)\s*章/)
+  if (chineseChapter) return Number(chineseChapter[1])
+
+  const slugChapter = stem.match(/chapter[-_\s]*0*(\d+)/i)
+  if (slugChapter) return Number(slugChapter[1])
+
+  const numericStem = stem.match(/^0*(\d+)$/)
+  if (numericStem) return Number(numericStem[1])
+
+  return undefined
+}
+
+export function resolveReviewChapterTarget(fileContent: string, selectedFile: string): ReviewChapterTarget {
+  const parsed = parseFrontmatter(fileContent)
+  const meta = parsed.frontmatter ? parseChapterMeta(parsed.frontmatter as Record<string, unknown>) : null
+  const selectedChapterNumber = parseChapterNumberFromSelectedFile(selectedFile)
+
+  return {
+    chapterNumber: selectedChapterNumber ?? meta?.chapterNumber,
+  }
 }
 
 export async function startNovelReviewRun({
@@ -23,13 +52,12 @@ export async function startNovelReviewRun({
 }: StartNovelReviewRunArgs): Promise<void> {
   if (!selectedFile || !fileContent.trim()) return
 
-  const parsed = parseFrontmatter(fileContent)
-  const meta = parsed.frontmatter ? parseChapterMeta(parsed.frontmatter as Record<string, unknown>) : null
+  const target = resolveReviewChapterTarget(fileContent, selectedFile)
   const runId = `${Date.now()}-${Math.random()}`
   useWikiStore.getState().setReviewRun({ runId, projectPath, filePath: selectedFile, running: true, results: [] })
 
   try {
-    const results = await reviewChapter(projectPath, fileContent, meta?.chapterNumber, {
+    const results = await reviewChapter(projectPath, fileContent, target.chapterNumber, {
       onThinking: (thinking) => {
         useWikiStore.getState().finishReviewRun(runId, { running: true, thinking })
       },
@@ -37,17 +65,17 @@ export async function startNovelReviewRun({
     useWikiStore.getState().finishReviewRun(runId, { running: true, results, error: undefined })
     await saveGenerationHistoryEntry(projectPath, {
       kind: "review",
-      title: meta?.chapterNumber ? t("novel.review.historyEntryTitle", { chapter: meta.chapterNumber }) : t("novel.review.historyEntryTitleNoChapter"),
-      chapterNumber: meta?.chapterNumber,
+      title: target.chapterNumber ? t("novel.review.historyEntryTitle", { chapter: target.chapterNumber }) : t("novel.review.historyEntryTitleNoChapter"),
+      chapterNumber: target.chapterNumber,
       sourcePath: selectedFile,
       results,
     })
     await onHistorySaved?.()
 
-    if (meta?.chapterNumber) {
+    if (target.chapterNumber) {
       await persistRevisionFeedbackForChapter(
         projectPath,
-        meta.chapterNumber,
+        target.chapterNumber,
         "review",
         pickRevisionFeedbackFromReviewResults(results),
       )

--- a/src/lib/novel/start-six-dimension-review-run.spec.ts
+++ b/src/lib/novel/start-six-dimension-review-run.spec.ts
@@ -121,4 +121,45 @@ describe("startSixDimensionReviewRun", () => {
       }),
     )
   })
+
+  it("coalesces high-frequency dimension thinking updates before writing to the store", async () => {
+    let thinkingUpdateCount = 0
+    const unsubscribe = useWikiStore.subscribe((state, previousState) => {
+      const nextThinking = state.reviewRun?.dimensionThinking?.thrill
+      const previousThinking = previousState.reviewRun?.dimensionThinking?.thrill
+      if (nextThinking && nextThinking !== previousThinking) {
+        thinkingUpdateCount += 1
+      }
+    })
+
+    mocks.runSixDimensionReview.mockImplementation(async (args: {
+      callbacks?: {
+        onDimensionThinking?: (dimensionKey: string, thinking: string) => void
+        onDimensionResult?: (dimensionKey: string, result: DimensionReviewResult) => void
+      }
+    }) => {
+      args.callbacks?.onDimensionThinking?.("thrill", "## 爽感密度\n开始")
+      for (let i = 0; i < 50; i += 1) {
+        args.callbacks?.onDimensionThinking?.("thrill", `## 爽感密度\n流式片段 ${i}`)
+      }
+      args.callbacks?.onDimensionResult?.("thrill", dimensionResult("thrill"))
+      return {
+        thrill: dimensionResult("thrill"),
+      }
+    })
+
+    try {
+      await startSixDimensionReviewRun({
+        fileContent: "---\nchapterNumber: 8\n---\n正文",
+        projectPath: "E:/Novel",
+        selectedFile: "E:/Novel/wiki/chapters/008.md",
+        t: ((key: string) => key) as never,
+      })
+    } finally {
+      unsubscribe()
+    }
+
+    expect(thinkingUpdateCount).toBeLessThanOrEqual(3)
+    expect(useWikiStore.getState().reviewRun?.dimensionThinking?.thrill).toContain("流式片段 49")
+  })
 })

--- a/src/lib/novel/start-six-dimension-review-run.ts
+++ b/src/lib/novel/start-six-dimension-review-run.ts
@@ -4,6 +4,7 @@ import { parseChapterMeta } from "@/lib/novel/chapter-meta"
 import { saveGenerationHistoryEntry } from "@/lib/novel/generation-history"
 import { runSixDimensionReview, type SixReviewDimensionKey } from "@/lib/novel/dimension-review-adapter"
 import { useWikiStore } from "@/stores/wiki-store"
+import { createReviewThinkingPublisher, type ReviewThinkingPublisher } from "./review-thinking-publisher"
 
 interface StartSixDimensionReviewRunArgs {
   fileContent: string
@@ -40,6 +41,32 @@ export async function startSixDimensionReviewRun({
     dimensionResults: preservedDimensionResults,
     dimensionThinking: {},
   })
+  const dimensionThinkingPublishers = new Map<SixReviewDimensionKey, ReviewThinkingPublisher>()
+  const getThinkingPublisher = (dimensionKey: SixReviewDimensionKey) => {
+    const existing = dimensionThinkingPublishers.get(dimensionKey)
+    if (existing) return existing
+
+    const publisher = createReviewThinkingPublisher({
+      publish: (thinking) => {
+        const current = useWikiStore.getState().reviewRun
+        useWikiStore.getState().finishReviewRun(runId, {
+          running: true,
+          activeDimension: dimensionKey,
+          dimensionThinking: {
+            ...(current?.dimensionThinking ?? {}),
+            [dimensionKey]: thinking,
+          },
+        })
+      },
+    })
+    dimensionThinkingPublishers.set(dimensionKey, publisher)
+    return publisher
+  }
+  const flushThinkingPublishers = () => {
+    for (const publisher of dimensionThinkingPublishers.values()) {
+      publisher.flush()
+    }
+  }
 
   try {
     const dimensionResults = await runSixDimensionReview({
@@ -56,17 +83,10 @@ export async function startSixDimensionReviewRun({
           })
         },
         onDimensionThinking: (dimensionKey, thinking) => {
-          const current = useWikiStore.getState().reviewRun
-          useWikiStore.getState().finishReviewRun(runId, {
-            running: true,
-            activeDimension: dimensionKey,
-            dimensionThinking: {
-              ...(current?.dimensionThinking ?? {}),
-              [dimensionKey]: thinking,
-            },
-          })
+          getThinkingPublisher(dimensionKey).publish(thinking)
         },
         onDimensionResult: (dimensionKey, result) => {
+          getThinkingPublisher(dimensionKey).flush()
           const current = useWikiStore.getState().reviewRun
           useWikiStore.getState().finishReviewRun(runId, {
             running: true,
@@ -79,6 +99,7 @@ export async function startSixDimensionReviewRun({
         },
       },
     })
+    flushThinkingPublishers()
 
     const nextDimensionResults = {
       ...preservedDimensionResults,
@@ -101,8 +122,10 @@ export async function startSixDimensionReviewRun({
     await onHistorySaved?.()
   } catch (error) {
     console.error("六维审查失败:", error)
+    flushThinkingPublishers()
     useWikiStore.getState().finishReviewRun(runId, { running: false, error: t("novel.review.runFailed") })
   } finally {
+    flushThinkingPublishers()
     const current = useWikiStore.getState().reviewRun
     if (current?.runId === runId) {
       useWikiStore.getState().finishReviewRun(runId, {

--- a/src/lib/novel/start-six-dimension-review-run.ts
+++ b/src/lib/novel/start-six-dimension-review-run.ts
@@ -5,6 +5,7 @@ import { saveGenerationHistoryEntry } from "@/lib/novel/generation-history"
 import { runSixDimensionReview, type SixReviewDimensionKey } from "@/lib/novel/dimension-review-adapter"
 import { useWikiStore } from "@/stores/wiki-store"
 import { createReviewThinkingPublisher, type ReviewThinkingPublisher } from "./review-thinking-publisher"
+import { yieldToBrowserFrame } from "./yield-to-browser"
 
 interface StartSixDimensionReviewRunArgs {
   fileContent: string
@@ -41,6 +42,7 @@ export async function startSixDimensionReviewRun({
     dimensionResults: preservedDimensionResults,
     dimensionThinking: {},
   })
+  await yieldToBrowserFrame()
   const dimensionThinkingPublishers = new Map<SixReviewDimensionKey, ReviewThinkingPublisher>()
   const getThinkingPublisher = (dimensionKey: SixReviewDimensionKey) => {
     const existing = dimensionThinkingPublishers.get(dimensionKey)

--- a/src/lib/novel/yield-to-browser.ts
+++ b/src/lib/novel/yield-to-browser.ts
@@ -1,0 +1,11 @@
+export function yieldToBrowserFrame(): Promise<void> {
+  if (typeof window !== "undefined" && typeof window.requestAnimationFrame === "function") {
+    return new Promise((resolve) => {
+      window.requestAnimationFrame(() => {
+        window.setTimeout(resolve, 0)
+      })
+    })
+  }
+
+  return new Promise((resolve) => setTimeout(resolve, 0))
+}

--- a/src/lib/search.spec.ts
+++ b/src/lib/search.spec.ts
@@ -1,0 +1,36 @@
+import { beforeEach, expect, test, vi } from "vitest"
+import type { FileNode } from "@/types/wiki"
+
+vi.mock("@/commands/fs", () => ({
+  listDirectory: vi.fn(),
+  readFile: vi.fn(),
+}))
+
+import { listDirectory, readFile } from "@/commands/fs"
+import { searchWiki } from "./search"
+
+const mockedListDirectory = vi.mocked(listDirectory)
+const mockedReadFile = vi.mocked(readFile)
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+test("can cap content scanned for token matching", async () => {
+  const files: FileNode[] = [
+    {
+      name: "big-source.md",
+      path: "/Project/wiki/sources/big-source.md",
+      is_dir: false,
+    },
+  ]
+  mockedListDirectory.mockResolvedValue(files)
+  mockedReadFile.mockResolvedValue(`# Big Source\n${"x".repeat(2000)}needle`)
+
+  const results = await searchWiki("/Project", "needle", {
+    includeVector: false,
+    maxContentChars: 100,
+  } as Parameters<typeof searchWiki>[2])
+
+  expect(results).toEqual([])
+})

--- a/src/lib/search.ts
+++ b/src/lib/search.ts
@@ -37,6 +37,7 @@ export interface SearchWikiOptions {
   topK?: number
   rerankPurpose?: string
   includeVector?: boolean
+  maxContentChars?: number
 }
 
 const MAX_RESULTS = 20
@@ -265,7 +266,7 @@ export async function searchWiki(
     const tList = Math.round(performance.now() - t0)
     console.log("[searchWiki] wikiFiles:", wikiFiles.length)
     const t1 = performance.now()
-    await searchFiles(wikiFiles, effectiveTokens, query, results)
+    await searchFiles(wikiFiles, effectiveTokens, query, results, options)
     const tRead = Math.round(performance.now() - t1)
     console.log("[searchWiki] searchFiles done in", tRead, "ms")
     console.log(
@@ -435,6 +436,7 @@ async function searchFiles(
   tokens: readonly string[],
   query: string,
   results: SearchResult[],
+  options: SearchWikiOptions,
 ): Promise<void> {
   // Strip leading / trailing punctuation from the query before using
   // it as a phrase-bonus probe. Without this, `query="总资产。"`
@@ -465,14 +467,34 @@ async function searchFiles(
         } catch {
           return null
         }
-        return scoreFile(file, content, tokens, queryPhrase, query)
+        return scoreFile(
+          file,
+          applyContentScanLimit(content, options.maxContentChars),
+          tokens,
+          queryPhrase,
+          query,
+        )
       }),
     )
     console.log("[searchFiles] batch", batchNum, "done, matched", batchResults.filter(Boolean).length)
     for (const r of batchResults) {
       if (r) results.push(r)
     }
+    if (i + SEARCH_READ_CONCURRENCY < files.length) {
+      await yieldToEventLoop()
+    }
   }
+}
+
+function applyContentScanLimit(content: string, maxContentChars: number | undefined): string {
+  if (!maxContentChars || maxContentChars <= 0 || content.length <= maxContentChars) {
+    return content
+  }
+  return content.slice(0, maxContentChars)
+}
+
+function yieldToEventLoop(): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, 0))
 }
 
 /**
@@ -539,4 +561,3 @@ function scoreFile(
     images: extractImageRefs(content),
   }
 }
-

--- a/src/lib/tauri-fetch.test.ts
+++ b/src/lib/tauri-fetch.test.ts
@@ -1,0 +1,19 @@
+import { afterEach, expect, test, vi } from "vitest"
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+  vi.resetModules()
+})
+
+test("uses native fetch in a plain browser without Tauri internals", async () => {
+  const nativeFetch = vi.fn(async () => new Response("ok"))
+
+  vi.stubGlobal("window", {})
+  vi.stubGlobal("fetch", nativeFetch)
+
+  const { getHttpFetch } = await import("./tauri-fetch")
+  const httpFetch = await getHttpFetch()
+
+  await expect(httpFetch("https://example.com")).resolves.toBeInstanceOf(Response)
+  expect(nativeFetch).toHaveBeenCalledWith("https://example.com")
+})

--- a/src/lib/tauri-fetch.ts
+++ b/src/lib/tauri-fetch.ts
@@ -11,10 +11,9 @@
  *  - Any enterprise / on-prem gateway that doesn't anticipate browser
  *    origins — a common shape across domestic Chinese clouds
  *
- * In unit tests (vitest / node), the plugin's browser-only globals
- * aren't available; `getHttpFetch` lazily imports and falls back to
- * `globalThis.fetch` so helper functions in this file can be imported
- * from any environment without crashing at module load.
+ * In unit tests (vitest / node) and plain browser previews, the Tauri
+ * IPC globals aren't available. `getHttpFetch` only imports the plugin
+ * inside a real Tauri webview; everywhere else it uses native fetch.
  */
 
 let pluginFetchPromise: Promise<typeof globalThis.fetch> | null = null
@@ -27,6 +26,8 @@ let pluginFetchPromise: Promise<typeof globalThis.fetch> | null = null
  * import rather than trying to .catch() an error that happens later.
  */
 const isNodeEnv = typeof window === "undefined"
+const isTauriEnv = (): boolean =>
+  typeof window !== "undefined" && "__TAURI_INTERNALS__" in window
 
 /**
  * Returns a fetch function that routes through Tauri's HTTP plugin in
@@ -40,7 +41,7 @@ const isNodeEnv = typeof window === "undefined"
  */
 export function getHttpFetch(): Promise<typeof globalThis.fetch> {
   if (!pluginFetchPromise) {
-    if (isNodeEnv) {
+    if (isNodeEnv || !isTauriEnv()) {
       // Bind so `this === globalThis` — Node's fetch requires it.
       pluginFetchPromise = Promise.resolve(globalThis.fetch.bind(globalThis))
     } else {

--- a/src/lib/web-fs.spec.ts
+++ b/src/lib/web-fs.spec.ts
@@ -1,0 +1,25 @@
+import { expect, test } from "vitest"
+import { getWebFs } from "./web-fs"
+
+test("lists parent nodes for nested empty directories created in web fs", async () => {
+  const fs = getWebFs()
+  const root = `/web-fs-test-${Date.now()}/wiki`
+
+  await fs.createDirectory(`${root}/empty/nested`)
+
+  await expect(fs.listDirectory(root)).resolves.toEqual([
+    {
+      name: "empty",
+      path: `${root}/empty`,
+      is_dir: true,
+      children: [
+        {
+          name: "nested",
+          path: `${root}/empty/nested`,
+          is_dir: true,
+          children: [],
+        },
+      ],
+    },
+  ])
+})

--- a/src/lib/web-fs.ts
+++ b/src/lib/web-fs.ts
@@ -84,58 +84,106 @@ class WebFileSystem {
   }
 
   private listDirectoryTree(normalizedPath: string): FileNode[] {
-    const children: FileNode[] = []
-    const seenDirs = new Set<string>()
-    const seenFiles = new Set<string>()
+    type MutableDirNode = {
+      name: string
+      path: string
+      is_dir: true
+      children: Map<string, MutableTreeNode>
+    }
+    type MutableFileNode = {
+      name: string
+      path: string
+      is_dir: false
+    }
+    type MutableTreeNode = MutableDirNode | MutableFileNode
 
-    for (const [filePath] of this.files.entries()) {
-      if (!filePath.startsWith(normalizedPath + "/")) continue
-      const relative = filePath.slice(normalizedPath.length + 1)
-      const firstSegment = relative.split("/")[0]
-      if (!firstSegment) continue
+    const rootChildren = new Map<string, MutableTreeNode>()
+    const prefix = `${normalizedPath}/`
 
-      if (relative.includes("/")) {
-        if (!seenDirs.has(firstSegment)) {
-          seenDirs.add(firstSegment)
-          const dirPath = `${normalizedPath}/${firstSegment}`
-          children.push({
-            name: firstSegment,
-            path: dirPath,
-            is_dir: true,
-            children: this.listDirectoryTree(dirPath),
-          })
-        }
-      } else {
-        if (!seenFiles.has(firstSegment)) {
-          seenFiles.add(firstSegment)
-          children.push({
-            name: firstSegment,
-            path: `${normalizedPath}/${firstSegment}`,
-            is_dir: false,
-          })
-        }
+    const ensureDir = (
+      children: Map<string, MutableTreeNode>,
+      name: string,
+      path: string,
+    ): MutableDirNode => {
+      const existing = children.get(name)
+      if (existing?.is_dir) return existing
+      const node: MutableDirNode = {
+        name,
+        path,
+        is_dir: true,
+        children: new Map(),
+      }
+      children.set(name, node)
+      return node
+    }
+
+    const addDir = (dirPath: string) => {
+      if (!dirPath.startsWith(prefix)) return
+      const segments = dirPath.slice(prefix.length).split("/").filter(Boolean)
+      if (segments.length === 0) return
+
+      let children = rootChildren
+      let currentPath = normalizedPath
+      for (const segment of segments) {
+        currentPath = `${currentPath}/${segment}`
+        const node = ensureDir(children, segment, currentPath)
+        children = node.children
       }
     }
 
-    for (const dir of this.dirs) {
-      if (!dir.startsWith(normalizedPath + "/")) continue
-      const relative = dir.slice(normalizedPath.length + 1)
-      const firstSegment = relative.split("/")[0]
-      if (!firstSegment || relative.includes("/")) continue
+    const addFile = (filePath: string) => {
+      if (!filePath.startsWith(prefix)) return
+      const segments = filePath.slice(prefix.length).split("/").filter(Boolean)
+      if (segments.length === 0) return
 
-      if (!seenDirs.has(firstSegment)) {
-        seenDirs.add(firstSegment)
-        const dirPath = `${normalizedPath}/${firstSegment}`
-        children.push({
-          name: firstSegment,
-          path: dirPath,
-          is_dir: true,
-          children: this.listDirectoryTree(dirPath),
+      let children = rootChildren
+      let currentPath = normalizedPath
+      for (const segment of segments.slice(0, -1)) {
+        currentPath = `${currentPath}/${segment}`
+        const node = ensureDir(children, segment, currentPath)
+        children = node.children
+      }
+
+      const fileName = segments[segments.length - 1]
+      const existing = children.get(fileName)
+      if (!existing) {
+        children.set(fileName, {
+          name: fileName,
+          path: filePath,
+          is_dir: false,
         })
       }
     }
 
-    return children
+    const toFileNodes = (children: Map<string, MutableTreeNode>): FileNode[] => {
+      const nodes: FileNode[] = []
+      for (const node of children.values()) {
+        if (node.is_dir) {
+          nodes.push({
+            name: node.name,
+            path: node.path,
+            is_dir: true,
+            children: toFileNodes(node.children),
+          })
+        } else {
+          nodes.push({
+            name: node.name,
+            path: node.path,
+            is_dir: false,
+          })
+        }
+      }
+      return nodes
+    }
+
+    for (const [filePath] of this.files.entries()) {
+      addFile(filePath)
+    }
+    for (const dir of this.dirs) {
+      addDir(dir)
+    }
+
+    return toFileNodes(rootChildren)
   }
 
   async createDirectory(path: string): Promise<void> {


### PR DESCRIPTION
## What changed

- Fix browser model-test requests so plain web previews use native `fetch` while real Tauri webviews continue to use the Tauri HTTP plugin.
- Load optional environment-provided LLM defaults on first launch when no project config exists.
- Fix AI review history targeting by deriving the chapter number from the selected chapter file when frontmatter is stale.
- Fix chat copy/save behavior so generated chapter edit content is copied/saved instead of surrounding outline/context text.
- Accept both `anchorText`/`insertText` and the prompt-requested `anchor_text`/`insert_text` keys for dashboard fact-check rewrite plans.

## Root cause

- Review history trusted chapter frontmatter even when the selected file was a different chapter.
- Chat copy used raw assistant message text instead of the parsed chapter edit replacement.
- Dashboard fact-check rewrite prompt requested snake_case JSON keys, but the parser only accepted camelCase.
- Browser preview tried to import/use Tauri HTTP behavior without Tauri internals.

## Validation

- `npx vitest run src/lib/dashboard-issue-actions.test.ts src/lib/novel/start-review-run.test.ts src/lib/chat-copy-content.test.ts src/lib/tauri-fetch.test.ts`
- `npm run build`
