### PR TITLE
fix: 修复章节路由、frontmatter写回与字数控制多个问题

### DIFF
--- a/GenxinLOG/更新日志.md
+++ b/GenxinLOG/更新日志.md
@@ -1,0 +1,25 @@
+# 更新日志
+
+## 20260611-23:00
+
+版本：2.2.12（未提交 GitHub，沿用当前版本号）
+
+1. 修复"继续生成下一章"会重复生成第一章的问题（issue #6 #9）：
+   - 提示词中顺带出现的"开篇/第一章/开局"等字样不再把目标章节劫持为第 1 章（task-router.ts、golden-three-chapters.ts）。
+   - 已解析出的目标章节号优先于文本关键词；目标章节 ≥ 4 时不再误启黄金三章模式。
+   - "下一章"续写语义优先：续写请求中引用其他章节号（如"不要重复第一章内容"）不再改变目标章节。
+2. 继续生成下一章会记住本会话刚生成、尚未保存的章节号（chapter-utils.ts 新增 detectLastGeneratedChapterNumber）：第 1 章生成后未保存就点"继续生成下一章"，不再因章节库为空而重写第 1 章。
+3. 修复 AI 修改章节时"返回内容缺少 frontmatter，已停止写回"的问题（issue #10，chapter-edit-file.ts）：
+   - 模型只返回正文时自动沿用原章节 frontmatter；原文件也没有时按章节库默认格式补齐。
+   - 容错代码围栏包裹、【第N章】标记行；正文缺少标题行时自动补"# 第N章"。
+   - 仅在返回内容完全为空时才拒绝写回。
+4. 新增"单章目标字数"设置（issue #8，设置 → 小说写作设置）：
+   - 章节生成、扩写补足阈值、输出 token 上限和"继续生成下一章"提示词都按设置目标推算（deep-chapter-prompts.ts resolveChapterLengthSpec）。
+   - 默认 3000 字，可设 500-20000；配置按项目持久化。
+5. 修复点击停止后审稿阶段可能无法停止的问题（review-adapter.ts combineSignals）：停止信号在审稿开始前已生效时，组合信号现在会立即中止。
+6. 修复 2.2.12 发布分支遗留的 10 个测试失败（过时断言与乱码编码），并补充 changelog 2.2.12 条目；release-notes.spec.mjs 重写为 UTF-8。
+7. 新增回归测试：task-router（4 个）、golden-three-chapters（3 个）、chapter-utils（5 个）、chapter-edit-file（6 个）、deep-chapter-prompts（5 个）、review-adapter（1 个）。
+
+验证：npm run typecheck 通过；npm run test:mocks 62 个测试文件 / 217 个测试全部通过（修复前该分支有 10 个失败）。
+
+未提交 git；本机无 Rust 工具链，未执行 exe 打包（npm run build 前端生产构建已验证）。

--- a/scripts/release-notes.spec.mjs
+++ b/scripts/release-notes.spec.mjs
@@ -1,4 +1,4 @@
-﻿import { describe, expect, it } from "vitest"
+import { describe, expect, it } from "vitest"
 import { execFileSync } from "node:child_process"
 import { mkdtempSync, readFileSync } from "node:fs"
 import { tmpdir } from "node:os"
@@ -9,15 +9,13 @@ describe("release notes for updater manifest", () => {
   it("uses the full Chinese changelog for the current package version", async () => {
     const notes = await buildCurrentReleaseNotes()
 
-    expect(notes).not.toBe("QMAI 2.2.1 鍙戝竷鐗堟湰")
+    expect(notes).not.toMatch(/^QMAI [\d.]+ 发布版本$/)
     expect(notes).toContain("1. ")
-    expect(notes).toContain("修复 AI 会话“保存到章节库”后")
-    expect(notes).toContain("2200-3200")
-    expect(notes).toContain("本地 Claude Code CLI / Codex CLI")
+    expect(notes).toContain("继续生成下一章")
+    expect(notes).toContain("frontmatter")
+    expect(notes).toContain("单章目标字数")
     expect(notes.split("\n")).toHaveLength(9)
-    expect(notes).not.toContain("鍚屾宸茬‘璁ゅ彲浠ユ帴鍙楃殑 PR 淇")
     expect(notes).not.toContain(".codex-temp")
-    expect(notes).not.toContain("鑱旂郴鏂瑰紡")
   })
 
   it("can write release notes directly to a UTF-8 file for CI scripts", () => {

--- a/src/components/chat/chat-message.spec.tsx
+++ b/src/components/chat/chat-message.spec.tsx
@@ -91,8 +91,9 @@ describe("deep chapter unfinished continuation action", () => {
   it("keeps the ai chat footer labels as readable Chinese text", () => {
     const source = readFileSync(resolve(__dirname, "chat-panel.tsx"), "utf8")
 
-    expect(source).toContain("深度章节生成")
-    expect(source).toContain("修改模式")
+    expect(source).toContain("深度思考")
+    expect(source).toContain("普通模式")
+    expect(source).toContain("编辑章节")
     expect(source).toContain("AI会话模型")
     expect(source).toContain("跟随当前主模型")
   })

--- a/src/components/chat/chat-panel.tsx
+++ b/src/components/chat/chat-panel.tsx
@@ -10,12 +10,13 @@ import { setLastQueryPages, useSourceFiles } from "./chat-shared"
 import { ChatInput } from "./chat-input"
 import { useChatStore, chatMessagesToLLM, type DisplayMessage } from "@/stores/chat-store"
 import { useWikiStore } from "@/stores/wiki-store"
+import { resolveChapterLengthSpec } from "@/lib/novel/deep-chapter-prompts"
 import { streamChat, type ChatMessage as LLMMessage } from "@/lib/llm-client"
 import { executeIngestWrites } from "@/lib/ingest"
 import { routeTask, buildTaskDirective } from "@/lib/novel/task-router"
 import { listDirectory, readFile, writeFile, createDirectory, deleteFile } from "@/commands/fs"
 import { searchWiki, tokenizeQuery } from "@/lib/search"
-import { findChapterFileByNumber, getNextChapterNumber, readSelectedChapterNumberForFile, resolveTargetChapterNumberForChat } from "@/lib/novel/chapter-utils"
+import { detectLastGeneratedChapterNumber, findChapterFileByNumber, getNextChapterNumber, readSelectedChapterNumberForFile, resolveTargetChapterNumberForChat } from "@/lib/novel/chapter-utils"
 import { buildQmQuaiSystemPrompt, injectDeAiDirective } from "@/lib/novel/de-ai-adapter"
 import { cleanGeneratedChapterContentForSave } from "@/lib/novel/chapter-content-cleanup"
 import { normalizePath, getFileName, getRelativePath } from "@/lib/path-utils"
@@ -353,6 +354,14 @@ export function ChatPanel() {
       let langReminder: string | undefined
       const taskRoute = novelMode ? routeTask(text) : null
       const pp = project ? normalizePath(project.path) : ""
+      // 会话内上次生成的章节号：未保存到章节库时也能正确推进“下一章”
+      const lastGeneratedChapterNumber = novelMode && project
+        ? detectLastGeneratedChapterNumber(
+          useChatStore.getState().getActiveMessages()
+            .filter((m) => m.role === "assistant" && !m.discarded)
+            .map((m) => m.content),
+        )
+        : undefined
       const targetChapterNumber = novelMode && project && taskRoute
         ? await resolveTargetChapterNumberForChat({
           projectPath: pp,
@@ -360,6 +369,7 @@ export function ChatPanel() {
           routeIntent: taskRoute.intent,
           routeChapterNumber: taskRoute.chapterNumber,
           selectedFile,
+          lastGeneratedChapterNumber,
         })
         : undefined
       const effectiveTaskRoute = taskRoute && targetChapterNumber
@@ -495,6 +505,7 @@ export function ChatPanel() {
           const normalizedResult = normalizeChapterEditFile({
             targetChapterNumber: chapter.chapterNumber,
             content: rawResult,
+            originalContent: chapter.content,
           })
           if (!normalizedResult.ok) {
             finalizeStream(normalizedResult.message, [])
@@ -1024,7 +1035,10 @@ export function ChatPanel() {
 
   const handleContinueNextChapter = useCallback(() => {
     if (isStreaming) return
-    handleSend("请根据当前小说上下文、记忆库、最新章节结尾、下一章推进建议和章纲，继续生成下一章正文。只输出可直接保存到章节库的小说正文，不要解释，不要列提纲。正文必须是完整章节，目标约 3000 字，建议 2800-3300 字，低于 2600 字视为未完成。")
+    // 按设置中的单章目标字数生成提示词（issue #8）
+    const lengthSpec = resolveChapterLengthSpec(useWikiStore.getState().novelConfig?.chapterTargetChars)
+    const target = lengthSpec.targetChars
+    handleSend(`请根据当前小说上下文、记忆库、最新章节结尾、下一章推进建议和章纲，继续生成下一章正文。只输出可直接保存到章节库的小说正文，不要解释，不要列提纲。正文必须是完整章节，目标约 ${target} 字，建议 ${target - 200}-${target + 300} 字，低于 ${target - 400} 字视为未完成。`)
   }, [handleSend, isStreaming])
 
   const handleContinueUnfinished = useCallback(async (assistantMessage: DisplayMessage) => {

--- a/src/components/settings/sections/novel-section.tsx
+++ b/src/components/settings/sections/novel-section.tsx
@@ -258,6 +258,27 @@ export function NovelSection({ draft, setDraft }: Props) {
             </p>
           </div>
 
+          <div className="space-y-2">
+            <div className="flex items-center gap-1.5">
+              <Label>{t("novel.settings.chapterTargetChars")}</Label>
+              {settingTooltip("chapterTargetCharsHint")}
+            </div>
+            <Input
+              type="number"
+              min={500}
+              max={20000}
+              step={100}
+              value={draft.novelConfig.chapterTargetChars}
+              onChange={(e) => updateNovelConfig({
+                chapterTargetChars: Math.max(500, Math.min(20000, Number(e.target.value) || 3000)),
+              })}
+              className="w-32"
+            />
+            <p className="text-xs text-muted-foreground">
+              {t("novel.settings.chapterTargetCharsHint")}
+            </p>
+          </div>
+
           <div className="flex items-center justify-between gap-3">
             <div className="flex items-center gap-1.5">
               <Label>{t("novel.settings.autoIngestOnSave")}</Label>

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -1088,6 +1088,8 @@
       "contextTokenBudget": "Context Token Budget",
       "contextTokenBudgetHint": "0 means unlimited",
       "contextTokenBudgetHelp": "Limits the number of context tokens injected into one novel writing or extraction call. Use 0 for no extra limit.",
+      "chapterTargetChars": "Target Characters per Chapter",
+      "chapterTargetCharsHint": "Controls the target character count (whitespace excluded) for one generated chapter. Chapter drafting, expansion thresholds, and the continue-next-chapter prompt all derive from this target. Default is 3000.",
       "autoIngestOnSave": "Auto-ingest memory when saving canon chapters",
       "autoIngestOnSaveHint": "When enabled, saving a canon chapter automatically extracts characters, locations, events, relationships, and canon facts into the novel memory library for later search and continuation.",
       "reviewBeforeSave": "Auto-review before save",

--- a/src/i18n/zh.json
+++ b/src/i18n/zh.json
@@ -951,6 +951,8 @@
       "contextTokenBudget": "上下文 Token 预算",
       "contextTokenBudgetHint": "0 表示无限制",
       "contextTokenBudgetHelp": "限制一次小说写作或资料提取时可注入的上下文 Token 数量，避免提示词过长。设置为 0 时不做额外限制。",
+      "chapterTargetChars": "单章目标字数",
+      "chapterTargetCharsHint": "控制 AI 生成单章正文的目标字数（按去除空白后的字符数计）。章节生成、扩写补足和“继续生成下一章”的提示词都会按这个目标推算，默认 3000 字。",
       "autoIngestOnSave": "保存正式章节时自动提取记忆",
       "autoIngestOnSaveHint": "开启后，章节保存为正式章节时会自动从正文中提取人物、地点、事件、关系和设定，写入小说记忆库，方便后续检索和续写。",
       "reviewBeforeSave": "保存前自动审稿",

--- a/src/lib/changelog.spec.ts
+++ b/src/lib/changelog.spec.ts
@@ -2,18 +2,19 @@
 import { allChangelog, currentVersionChangelog } from "./changelog"
 
 describe("changelog", () => {
-  it("shows the 2.2.11 release before earlier visible releases", () => {
+  it("shows the 2.2.12 release before earlier visible releases", () => {
     const entries = allChangelog()
     const versions = entries.map((entry) => entry.version)
 
-    expect(versions[0]).toBe("2.2.11")
-    expect(versions[1]).toBe("2.2.10")
-    expect(versions[2]).toBe("2.2.9")
-    expect(versions[3]).toBe("2.2.8")
-    expect(versions[4]).toBe("2.2.7")
-    expect(versions[5]).toBe("2.2.0")
-    expect(versions[6]).toBe("2.1.0")
-    expect(versions[7]).toBe("2.0.0")
+    expect(versions[0]).toBe("2.2.12")
+    expect(versions[1]).toBe("2.2.11")
+    expect(versions[2]).toBe("2.2.10")
+    expect(versions[3]).toBe("2.2.9")
+    expect(versions[4]).toBe("2.2.8")
+    expect(versions[5]).toBe("2.2.7")
+    expect(versions[6]).toBe("2.2.0")
+    expect(versions[7]).toBe("2.1.0")
+    expect(versions[8]).toBe("2.0.0")
 
     for (let patch = 1; patch <= 6; patch += 1) {
       expect(versions).not.toContain(`2.2.${patch}`)

--- a/src/lib/changelog.ts
+++ b/src/lib/changelog.ts
@@ -20,6 +20,35 @@ const TWO_POINT_TWO_TEN_CHANGELOG: ChangelogEntry = {
   },
 }
 
+const TWO_POINT_TWO_TWELVE_CHANGELOG: ChangelogEntry = {
+  version: "2.2.12",
+  date: "2026-06-11",
+  highlights: {
+    en: [
+      "Fixed continue-next-chapter regenerating chapter 1: incidental 开篇/第一章 wording inside prompts no longer hijacks the target chapter.",
+      "Continue-next-chapter now remembers the chapter just generated in this conversation, so an empty chapter library no longer resets the target back to chapter 1.",
+      "Fixed AI chapter editing failing with \"missing frontmatter, write-back stopped\": the original chapter frontmatter is reattached automatically, and fenced output or missing headings are tolerated.",
+      "Added a per-chapter target character setting: chapter drafting, expansion thresholds, and the continue-next-chapter prompt all follow the configured target.",
+      "Fixed the review stage being unstoppable when the stop signal fired before the review started.",
+      "Fixed contradictory outline refinement checks by uniformly testing whether the target directory already contains .md files.",
+      "Fixed stage-4 AI review interruptions: timeout extended from 2 to 5 minutes with automatic retries.",
+      "Fixed stale thinking content showing up when creating or switching conversations.",
+      "Redesigned the AI chat footer: deep thinking and normal mode are mutually exclusive, and normal mode supports plain conversation plus chapter editing.",
+    ],
+    zh: [
+      "修复“继续生成下一章”会重复生成第一章的问题：提示词中顺带出现的“开篇/第一章”字样不再把目标章节劫持为第1章。",
+      "继续生成下一章会记住本会话刚生成、尚未保存的章节号，章节库为空时也能正确推进到下一章。",
+      "修复 AI 修改章节时“返回内容缺少 frontmatter，已停止写回”的问题：自动沿用原章节 frontmatter，并容错代码围栏与缺失标题。",
+      "新增“单章目标字数”设置：章节生成、扩写阈值和“继续生成下一章”提示词都按设置目标执行。",
+      "修复点击停止后审稿阶段可能无法停止的问题：停止信号在审稿开始前已生效时也会立即中止。",
+      "修复大纲细化生成逻辑矛盾，统一按目录是否已有 .md 文件判断。",
+      "修复 AI 审稿阶段4易中断问题：超时从 2 分钟延长到 5 分钟，并增加失败自动重试。",
+      "修复新建/切换会话时显示旧思考内容的问题。",
+      "AI 会话界面重做：深度思考与普通模式互斥切换，普通模式支持正常对话与编辑章节。",
+    ],
+  },
+}
+
 const TWO_POINT_TWO_ELEVEN_CHANGELOG: ChangelogEntry = {
   version: "2.2.11",
   date: "2026-06-10",
@@ -278,6 +307,7 @@ export const CHANGELOG: ChangelogEntry[] = [
 ]
 
 export function currentVersionChangelog(version: string): ChangelogEntry[] {
+  if (version === TWO_POINT_TWO_TWELVE_CHANGELOG.version) return [TWO_POINT_TWO_TWELVE_CHANGELOG]
   if (version === TWO_POINT_TWO_ELEVEN_CHANGELOG.version) return [TWO_POINT_TWO_ELEVEN_CHANGELOG]
   if (version === TWO_POINT_TWO_TEN_CHANGELOG.version) return [TWO_POINT_TWO_TEN_CHANGELOG]
   if (version === TWO_POINT_TWO_NINE_CHANGELOG.version) return [TWO_POINT_TWO_NINE_CHANGELOG]
@@ -286,7 +316,7 @@ export function currentVersionChangelog(version: string): ChangelogEntry[] {
   if (version === TWO_POINT_TWO_ZERO_CHANGELOG.version) return [TWO_POINT_TWO_ZERO_CHANGELOG]
   if (version === TWO_POINT_ONE_ZERO_CHANGELOG.version) return [TWO_POINT_ONE_ZERO_CHANGELOG]
   if (version === TWO_POINT_ZERO_CHANGELOG.version) return [TWO_POINT_ZERO_CHANGELOG]
-  if (/^2\.2\.(?:[1-6]|11|12|13)$/.test(version)) return []
+  if (/^2\.2\.(?:[1-6]|13)$/.test(version)) return []
   if (/^2\.1\.(?:[1-9]|10)$/.test(version)) return []
   if (/^2\.0\.(?:[1-9]|1[0-2])$/.test(version)) return []
   if (isMergedOnePointRelease(version)) return []
@@ -295,6 +325,7 @@ export function currentVersionChangelog(version: string): ChangelogEntry[] {
 
 export function allChangelog(): ChangelogEntry[] {
   return [
+    TWO_POINT_TWO_TWELVE_CHANGELOG,
     TWO_POINT_TWO_ELEVEN_CHANGELOG,
     TWO_POINT_TWO_TEN_CHANGELOG,
     TWO_POINT_TWO_NINE_CHANGELOG,

--- a/src/lib/novel/chapter-edit-file.spec.ts
+++ b/src/lib/novel/chapter-edit-file.spec.ts
@@ -1,6 +1,19 @@
 import { describe, expect, it } from "vitest"
 import { normalizeChapterEditFile } from "./chapter-edit-file"
 
+const ORIGINAL_CHAPTER = `---
+type: chapter
+chapter_number: 12
+chapter_status: draft
+title: "第12章"
+created: 2026-06-01
+---
+
+# 第12章
+
+这里是原始正文。
+`
+
 describe("normalizeChapterEditFile", () => {
   it("forces chapter_number and title to match the target chapter", () => {
     const result = normalizeChapterEditFile({
@@ -27,19 +40,37 @@ chapter_status: draft
     }
   })
 
-  it("rejects files without frontmatter", () => {
+  it("reattaches the original frontmatter when the model returns body-only content (issue #10)", () => {
+    const result = normalizeChapterEditFile({
+      targetChapterNumber: 12,
+      content: `# 第12章\n\n这里是模型修改后的正文。`,
+      originalContent: ORIGINAL_CHAPTER,
+    })
+
+    expect(result.ok).toBe(true)
+    if (result.ok) {
+      expect(result.content).toContain("type: chapter")
+      expect(result.content).toContain("chapter_number: 12")
+      expect(result.content).toContain("created: 2026-06-01")
+      expect(result.content).toContain("这里是模型修改后的正文。")
+    }
+  })
+
+  it("synthesizes default chapter frontmatter when neither side has one", () => {
     const result = normalizeChapterEditFile({
       targetChapterNumber: 12,
       content: `# 第12章\n\n这里只有正文`,
     })
 
-    expect(result).toEqual({
-      ok: false,
-      message: "第12章返回内容缺少 frontmatter，已停止写回。",
-    })
+    expect(result.ok).toBe(true)
+    if (result.ok) {
+      expect(result.content).toContain("type: chapter")
+      expect(result.content).toContain("chapter_number: 12")
+      expect(result.content).toContain('title: "第12章"')
+    }
   })
 
-  it("rejects files without a heading title", () => {
+  it("prepends a chapter heading when the modified body has none", () => {
     const result = normalizeChapterEditFile({
       targetChapterNumber: 12,
       content: `---
@@ -50,9 +81,37 @@ title: "第12章"
 这里只有正文，没有标题行`,
     })
 
+    expect(result.ok).toBe(true)
+    if (result.ok) {
+      expect(result.content).toContain("# 第12章\n\n这里只有正文，没有标题行")
+    }
+  })
+
+  it("strips wrapping code fences and 【第N章】 markers from model output", () => {
+    const result = normalizeChapterEditFile({
+      targetChapterNumber: 12,
+      content: "```markdown\n【第12章】\n修改后的正文从这里开始。\n```",
+      originalContent: ORIGINAL_CHAPTER,
+    })
+
+    expect(result.ok).toBe(true)
+    if (result.ok) {
+      expect(result.content).not.toContain("```")
+      expect(result.content).not.toContain("【第12章】")
+      expect(result.content).toContain("修改后的正文从这里开始。")
+    }
+  })
+
+  it("still rejects an empty modification result", () => {
+    const result = normalizeChapterEditFile({
+      targetChapterNumber: 12,
+      content: "   ",
+      originalContent: ORIGINAL_CHAPTER,
+    })
+
     expect(result).toEqual({
       ok: false,
-      message: "第12章返回内容缺少标题，已停止写回。",
+      message: "第12章返回内容缺少正文，已停止写回。",
     })
   })
 })

--- a/src/lib/novel/chapter-edit-file.ts
+++ b/src/lib/novel/chapter-edit-file.ts
@@ -3,17 +3,32 @@ import { parseFrontmatter } from "@/lib/frontmatter"
 export function normalizeChapterEditFile(input: {
   content: string
   targetChapterNumber: number
+  /**
+   * 章节文件的原始内容。模型返回的修改稿经常只有正文、没有
+   * frontmatter（编辑提示词本身只要求输出正文），此时自动沿用
+   * 原文件的 frontmatter，而不是拒绝写回（issue #10）。
+   */
+  originalContent?: string
 }): { ok: true; content: string } | { ok: false; message: string } {
-  const normalized = input.content.replace(/\r\n?/g, "\n").trim()
+  const normalized = stripModelWrapping(input.content, input.targetChapterNumber)
   const parsed = parseFrontmatter(normalized)
-  if (!parsed.frontmatter) {
-    return {
-      ok: false,
-      message: `第${input.targetChapterNumber}章返回内容缺少 frontmatter，已停止写回。`,
+
+  let frontmatterFields = parsed.frontmatter
+  let body = parsed.body.trim()
+
+  if (!frontmatterFields) {
+    // 模型没有返回 frontmatter：优先沿用原章节文件的 frontmatter，
+    // 原文件也没有时按章节库默认格式补一份，保证修改稿不丢失。
+    const original = input.originalContent ? parseFrontmatter(input.originalContent) : null
+    frontmatterFields = original?.frontmatter ?? {
+      type: "chapter",
+      chapter_number: String(input.targetChapterNumber),
+      chapter_status: "draft",
+      title: `第${input.targetChapterNumber}章`,
     }
+    body = normalized.trim()
   }
 
-  const body = parsed.body.trim()
   if (!body) {
     return {
       ok: false,
@@ -21,17 +36,9 @@ export function normalizeChapterEditFile(input: {
     }
   }
 
-  const titleMatch = body.match(/^#\s+(.+)$/m)
-  if (!titleMatch?.[1]?.trim()) {
-    return {
-      ok: false,
-      message: `第${input.targetChapterNumber}章返回内容缺少标题，已停止写回。`,
-    }
-  }
-
   const correctedTitle = `第${input.targetChapterNumber}章`
   const frontmatter = {
-    ...parsed.frontmatter,
+    ...frontmatterFields,
     chapter_number: String(input.targetChapterNumber),
     title: correctedTitle,
   }
@@ -41,10 +48,35 @@ export function normalizeChapterEditFile(input: {
     return key === "title" ? `${key}: "${safeValue.replace(/"/g, '\\"')}"` : `${key}: ${safeValue}`
   })
 
-  const correctedBody = body.replace(/^#\s+.+$/m, `# ${correctedTitle}`)
+  // 正文缺少标题行时自动补一行章节标题，而不是拒绝写回。
+  const hasHeading = /^#\s+.+$/m.test(body)
+  const correctedBody = hasHeading
+    ? body.replace(/^#\s+.+$/m, `# ${correctedTitle}`)
+    : `# ${correctedTitle}\n\n${body}`
 
   return {
     ok: true,
     content: `---\n${frontmatterLines.join("\n")}\n---\n\n${correctedBody}\n`,
   }
+}
+
+/**
+ * 剥离模型输出常见的包装：
+ * - 整段包在 ``` / ```markdown 代码围栏里
+ * - 按编辑提示词格式输出的【第N章】标记行
+ */
+function stripModelWrapping(content: string, targetChapterNumber: number): string {
+  let normalized = content.replace(/\r\n?/g, "\n").trim()
+
+  const fenceMatch = normalized.match(/^```[a-zA-Z]*\s*\n([\s\S]*?)\n?```\s*$/)
+  if (fenceMatch?.[1]) {
+    normalized = fenceMatch[1].trim()
+  }
+
+  normalized = normalized
+    .replace(new RegExp(`^【第${targetChapterNumber}章(?:原文)?】\\s*\\n?`), "")
+    .replace(/^【第\d+章(?:原文)?】\s*\n?/, "")
+    .trim()
+
+  return normalized
 }

--- a/src/lib/novel/chapter-utils.spec.ts
+++ b/src/lib/novel/chapter-utils.spec.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from "vitest"
-import { resolveTargetChapterNumberForChat } from "./chapter-utils"
+import { detectLastGeneratedChapterNumber, resolveTargetChapterNumberForChat } from "./chapter-utils"
 
 vi.mock("@/commands/fs", () => ({
   listDirectory: vi.fn(async () => [
@@ -43,5 +43,44 @@ describe("resolveTargetChapterNumberForChat", () => {
       routeIntent: "continue_chapter",
       selectedFile: "E:/Novel/wiki/chapters/chapter-007.md",
     })).resolves.toBeUndefined()
+  })
+
+  it("advances past the chapter generated in this conversation even when it is not saved yet (issue #6)", async () => {
+    await expect(resolveTargetChapterNumberForChat({
+      projectPath: "E:/Novel",
+      userRequest: "继续生成下一章",
+      routeIntent: "continue_chapter",
+      lastGeneratedChapterNumber: 8,
+    })).resolves.toBe(9)
+  })
+
+  it("keeps the library-derived next chapter when it is already ahead of the conversation", async () => {
+    await expect(resolveTargetChapterNumberForChat({
+      projectPath: "E:/Novel",
+      userRequest: "继续生成下一章",
+      routeIntent: "continue_chapter",
+      lastGeneratedChapterNumber: 3,
+    })).resolves.toBe(7)
+  })
+})
+
+describe("detectLastGeneratedChapterNumber", () => {
+  it("reads the deep-generation target chapter marker from the latest assistant message", () => {
+    expect(detectLastGeneratedChapterNumber([
+      "## 阶段1：上下文分析\n目标章节：第1章\n章节目标：开局",
+      "## 阶段1：上下文分析\n目标章节：第2章\n章节目标：冲突升级",
+    ])).toBe(2)
+  })
+
+  it("reads chapter heading lines from generated chapter content", () => {
+    expect(detectLastGeneratedChapterNumber([
+      "# 第3章\n\n夜色像一块浸了水的布。",
+    ])).toBe(3)
+  })
+
+  it("ignores ordinary answers that merely mention chapter numbers", () => {
+    expect(detectLastGeneratedChapterNumber([
+      "主角在第3章的时候已经拿到了钥匙，所以这里不冲突。",
+    ])).toBeUndefined()
   })
 })

--- a/src/lib/novel/chapter-utils.ts
+++ b/src/lib/novel/chapter-utils.ts
@@ -90,6 +90,12 @@ export interface ResolveTargetChapterNumberForChatInput {
   routeIntent?: NovelTaskIntent
   routeChapterNumber?: number
   selectedFile?: string | null
+  /**
+   * 当前会话里上一次已生成章节的章节号（可能还没保存到章节库）。
+   * 修复 issue #6：第1章生成成功但尚未保存时，点击“继续生成下一章”
+   * 不应因为章节库为空而再次生成第1章。
+   */
+  lastGeneratedChapterNumber?: number | null
 }
 
 export async function resolveTargetChapterNumberForChat(input: ResolveTargetChapterNumberForChatInput): Promise<number | undefined> {
@@ -101,12 +107,43 @@ export async function resolveTargetChapterNumberForChat(input: ResolveTargetChap
     return undefined
   }
 
+  const lastGenerated = input.lastGeneratedChapterNumber ?? 0
+  const minimumNextChapter = lastGenerated > 0 ? lastGenerated + 1 : 0
+
   const selectedChapterNumber = await readSelectedChapterNumber(input.selectedFile)
   if (selectedChapterNumber && selectedChapterNumber > 0) {
-    return selectedChapterNumber + 1
+    return Math.max(selectedChapterNumber + 1, minimumNextChapter)
   }
 
-  return getNextChapterNumber(input.projectPath)
+  return Math.max(await getNextChapterNumber(input.projectPath), minimumNextChapter)
+}
+
+const GENERATED_CHAPTER_PATTERNS = [
+  // 深度生成思考过程中的目标章节标记
+  /目标章节：第(\d+)章/,
+  /按黄金三章规则生成第(\d+)章正文/,
+  // 章节正文标题行
+  /^#\s*第\s*(\d+)\s*章/m,
+]
+
+/**
+ * 从会话的 AI 回复内容里识别上一次生成的章节号。
+ * 只匹配章节生成特有的强标记（思考过程目标章节、正文标题行），
+ * 避免普通问答里顺带提到“第N章”造成误判。
+ */
+export function detectLastGeneratedChapterNumber(assistantContents: string[]): number | undefined {
+  for (let index = assistantContents.length - 1; index >= 0; index -= 1) {
+    const content = assistantContents[index]
+    if (!content) continue
+    for (const pattern of GENERATED_CHAPTER_PATTERNS) {
+      const match = content.match(pattern)
+      if (match?.[1]) {
+        const chapterNumber = Number.parseInt(match[1], 10)
+        if (Number.isFinite(chapterNumber) && chapterNumber > 0) return chapterNumber
+      }
+    }
+  }
+  return undefined
 }
 
 function shouldResolveNextChapter(userRequest: string, routeIntent?: NovelTaskIntent): boolean {

--- a/src/lib/novel/deep-chapter-generation.spec.ts
+++ b/src/lib/novel/deep-chapter-generation.spec.ts
@@ -275,7 +275,7 @@ describe("runDeepChapterGeneration", () => {
 
     expect(result.finalContent).toBe(finalPolished)
     expect(deps.streamChat).toHaveBeenCalledTimes(4)
-    expect(deps.reviewChapter).toHaveBeenCalledWith("E:/Novel", expandedDraft, 3)
+    expect(deps.reviewChapter).toHaveBeenCalledWith("E:/Novel", expandedDraft, 3, expect.objectContaining({}))
     expect(thinking.join("\n")).toContain("阶段3：正文扩写补足")
     expect(thinking.join("\n")).toContain("阶段6：简单审查与去AI味")
   })
@@ -344,7 +344,7 @@ describe("runDeepChapterGeneration", () => {
 
     expect(result.draftContent).toBe(optimizedDraft)
     expect(result.finalContent).toBe(finalPolished)
-    expect(deps.reviewChapter).toHaveBeenCalledWith("E:/Novel", optimizedDraft, 3)
+    expect(deps.reviewChapter).toHaveBeenCalledWith("E:/Novel", optimizedDraft, 3, expect.objectContaining({}))
     expect(thinking.join("\n")).toContain("检测到模型重复输出")
   })
 
@@ -374,7 +374,7 @@ describe("runDeepChapterGeneration", () => {
     )
 
     expect(result.draftContent).toBe(longDraft)
-    expect(deps.reviewChapter).toHaveBeenCalledWith("E:/Novel", longDraft, 3)
+    expect(deps.reviewChapter).toHaveBeenCalledWith("E:/Novel", longDraft, 3, expect.objectContaining({}))
     expect(thinking.join("\n")).not.toContain("已达到本章字数上限")
     expect(thinking.join("\n")).not.toContain("内容已达到安全上限")
   })
@@ -404,7 +404,7 @@ describe("runDeepChapterGeneration", () => {
       deps,
     )
 
-    expect(deps.reviewChapter).toHaveBeenCalledWith("E:/Novel", overlongDraft, 3)
+    expect(deps.reviewChapter).toHaveBeenCalledWith("E:/Novel", overlongDraft, 3, expect.objectContaining({}))
     expect(deps.streamChat).toHaveBeenCalledTimes(3)
     expect(thinking.join("\n")).not.toContain("2200-3200")
     expect(thinking.join("\n")).not.toContain("字数优化")
@@ -435,7 +435,7 @@ describe("runDeepChapterGeneration", () => {
       deps,
     )
 
-    expect(deps.reviewChapter).toHaveBeenCalledWith("E:/Novel", draft, 3)
+    expect(deps.reviewChapter).toHaveBeenCalledWith("E:/Novel", draft, 3, expect.objectContaining({}))
     expect(deps.streamChat).toHaveBeenCalledTimes(3)
     expect(thinking.join("\n")).not.toContain("2200-3200")
   })
@@ -466,7 +466,7 @@ describe("runDeepChapterGeneration", () => {
     )
 
     expect(result.finalContent).toBe(finalPolished)
-    expect(deps.reviewChapter).toHaveBeenCalledWith("E:/Novel", draft, 3)
+    expect(deps.reviewChapter).toHaveBeenCalledWith("E:/Novel", draft, 3, expect.objectContaining({}))
     expect(deps.streamChat).toHaveBeenCalledTimes(3)
     expect(thinking.join("\n")).not.toContain("2200-3200")
     expect(thinking.join("\n")).not.toContain("连续尝试")
@@ -614,7 +614,7 @@ describe("runDeepChapterGeneration", () => {
       "E:/Novel",
       expect.any(String),
       3,
-      undefined,
+      expect.objectContaining({}),
       controller.signal,
     )
   })

--- a/src/lib/novel/deep-chapter-generation.ts
+++ b/src/lib/novel/deep-chapter-generation.ts
@@ -8,8 +8,8 @@ import { reviewChapter, type NovelReviewResult } from "./review-adapter"
 import type { TaskRouteResult } from "./task-router"
 import type { GoldenThreeChapterRequest } from "./golden-three-chapters"
 import {
-  DEEP_CHAPTER_MAX_OUTPUT_TOKENS,
-  DEEP_CHAPTER_MIN_CHARS,
+  resolveChapterLengthSpec,
+  type ChapterLengthSpec,
   buildDeepChapterBriefPrompt,
   buildDeepChapterDraftPrompt,
   buildDeepChapterExpansionPrompt,
@@ -151,6 +151,7 @@ export async function runDeepChapterGeneration(
   assertNotAborted(signal)
   const resumeCheckpoint = input.resumeCheckpoint
   const writingConfig = resolveWritingConfig(input.llmConfig)
+  const lengthSpec = resolveCurrentChapterLengthSpec()
   const contextPack = await safeBuildChapterContextPack(
     deps,
     input.projectPath,
@@ -180,6 +181,7 @@ export async function runDeepChapterGeneration(
           input.userRequest,
           input.chapterNumber,
           input.goldenThreeChapter,
+          lengthSpec,
         ),
       }],
       deps,
@@ -203,15 +205,16 @@ export async function runDeepChapterGeneration(
           input.userRequest,
           input.chapterNumber,
           input.goldenThreeChapter,
+          lengthSpec,
         ),
       }],
       deps,
       signal,
       (partial) => callbacks.onThinking?.(formatStageThinking("阶段3：正文初稿", partial)),
-      { max_tokens: DEEP_CHAPTER_MAX_OUTPUT_TOKENS },
+      { max_tokens: lengthSpec.maxOutputTokens },
     )
     assertNotAborted(signal)
-    if (countChapterChars(draftContent) < DEEP_CHAPTER_MIN_CHARS) {
+    if (countChapterChars(draftContent) < lengthSpec.minChars) {
       draftContent = await collectModelText(
         writingConfig,
         [{
@@ -223,12 +226,13 @@ export async function runDeepChapterGeneration(
             input.userRequest,
             input.chapterNumber,
             input.goldenThreeChapter,
+            lengthSpec,
           ),
         }],
         deps,
         signal,
         (partial) => callbacks.onThinking?.(formatStageThinking("阶段3：正文扩写补足", partial)),
-        { max_tokens: DEEP_CHAPTER_MAX_OUTPUT_TOKENS },
+        { max_tokens: lengthSpec.maxOutputTokens },
       )
       assertNotAborted(signal)
     }
@@ -290,7 +294,7 @@ export async function runDeepChapterGeneration(
       deps,
       signal,
       (partial) => callbacks.onThinking?.(formatStageThinking("阶段5：自动返修", partial)),
-      { max_tokens: DEEP_CHAPTER_MAX_OUTPUT_TOKENS },
+      { max_tokens: lengthSpec.maxOutputTokens },
     )
     assertNotAborted(signal)
     callbacks.onThinking?.(formatStageThinking(
@@ -322,6 +326,7 @@ export async function runDeepChapterGeneration(
     callbacks,
     deps,
     signal,
+    lengthSpec,
   )
   callbacks.onThinking?.(formatStageThinking(
     "阶段7：完成",
@@ -348,6 +353,7 @@ async function finalPolishChapter(
   callbacks: DeepChapterGenerationCallbacks,
   deps: DeepChapterGenerationDeps,
   signal?: AbortSignal,
+  lengthSpec: ChapterLengthSpec = resolveChapterLengthSpec(),
 ): Promise<string> {
   assertNotAborted(signal)
   callbacks.onThinking?.(formatStageThinking("阶段6：简单审查与去AI味", "正在进行最后一遍简单审查，去除复读、机械套话和 AI 味。"))
@@ -367,10 +373,15 @@ async function finalPolishChapter(
     deps,
     signal,
     (partial) => callbacks.onThinking?.(formatStageThinking("阶段6：简单审查与去AI味", partial)),
-    { max_tokens: DEEP_CHAPTER_MAX_OUTPUT_TOKENS },
+    { max_tokens: lengthSpec.maxOutputTokens },
   )
   assertNotAborted(signal)
   return polished.trim() ? polished : currentContent
+}
+
+function resolveCurrentChapterLengthSpec(): ChapterLengthSpec {
+  const novelConfig = useWikiStore.getState().novelConfig
+  return resolveChapterLengthSpec(novelConfig?.chapterTargetChars)
 }
 
 function resolveWritingConfig(llmConfig: LlmConfig): LlmConfig {

--- a/src/lib/novel/deep-chapter-prompts.spec.ts
+++ b/src/lib/novel/deep-chapter-prompts.spec.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest"
+import {
+  DEEP_CHAPTER_DRAFT_MAX_CHARS,
+  DEEP_CHAPTER_MAX_OUTPUT_TOKENS,
+  DEEP_CHAPTER_MIN_CHARS,
+  DEEP_CHAPTER_TARGET_CHARS,
+  buildDeepChapterBriefPrompt,
+  buildDeepChapterDraftPrompt,
+  resolveChapterLengthSpec,
+} from "./deep-chapter-prompts"
+
+describe("resolveChapterLengthSpec", () => {
+  it("keeps the built-in defaults when no target is configured", () => {
+    const spec = resolveChapterLengthSpec()
+
+    expect(spec.targetChars).toBe(DEEP_CHAPTER_TARGET_CHARS)
+    expect(spec.minChars).toBe(DEEP_CHAPTER_MIN_CHARS)
+    expect(spec.draftMaxChars).toBe(DEEP_CHAPTER_DRAFT_MAX_CHARS)
+    expect(spec.maxOutputTokens).toBe(DEEP_CHAPTER_MAX_OUTPUT_TOKENS)
+  })
+
+  it("derives all thresholds from a configured chapter target (issue #8)", () => {
+    const spec = resolveChapterLengthSpec(2000)
+
+    expect(spec.targetChars).toBe(2000)
+    expect(spec.minChars).toBeLessThan(2000)
+    expect(spec.minChars).toBeGreaterThan(1000)
+    expect(spec.draftMaxChars).toBe(2500)
+  })
+
+  it("scales output token budget up for long chapters", () => {
+    const spec = resolveChapterLengthSpec(6000)
+
+    expect(spec.maxOutputTokens).toBeGreaterThan(DEEP_CHAPTER_MAX_OUTPUT_TOKENS)
+  })
+
+  it("clamps unreasonable targets", () => {
+    expect(resolveChapterLengthSpec(10).targetChars).toBe(500)
+    expect(resolveChapterLengthSpec(999999).targetChars).toBe(20000)
+  })
+})
+
+describe("chapter prompts honor the configured length spec", () => {
+  it("injects the configured target into brief and draft prompts", () => {
+    const spec = resolveChapterLengthSpec(2000)
+    const brief = buildDeepChapterBriefPrompt("上下文", "继续生成下一章", 5, undefined, spec)
+    const draft = buildDeepChapterDraftPrompt("上下文", "任务书", "继续生成下一章", 5, undefined, spec)
+
+    expect(brief).toContain("目标约 2000 字")
+    expect(draft).toContain("目标约 2000 字")
+    expect(draft).toContain(`阶段3正文草稿最多 ${spec.draftMaxChars} 字`)
+    expect(draft).not.toContain("目标约 3000 字")
+  })
+})

--- a/src/lib/novel/deep-chapter-prompts.ts
+++ b/src/lib/novel/deep-chapter-prompts.ts
@@ -7,8 +7,38 @@ export const DEEP_CHAPTER_MIN_CHARS = 2200
 export const DEEP_CHAPTER_DRAFT_MAX_CHARS = 3500
 export const DEEP_CHAPTER_MAX_OUTPUT_TOKENS = 8000
 
-function chapterLengthBoundary(): string {
-  return `目标约 ${DEEP_CHAPTER_TARGET_CHARS} 字；低于 ${DEEP_CHAPTER_MIN_CHARS} 字视为正文初稿未完成。`
+/** 章节生成字数规格：由设置中的“单章目标字数”推算（issue #8）。 */
+export interface ChapterLengthSpec {
+  targetChars: number
+  minChars: number
+  draftMaxChars: number
+  maxOutputTokens: number
+}
+
+export const DEFAULT_CHAPTER_LENGTH_SPEC: ChapterLengthSpec = {
+  targetChars: DEEP_CHAPTER_TARGET_CHARS,
+  minChars: DEEP_CHAPTER_MIN_CHARS,
+  draftMaxChars: DEEP_CHAPTER_DRAFT_MAX_CHARS,
+  maxOutputTokens: DEEP_CHAPTER_MAX_OUTPUT_TOKENS,
+}
+
+export function resolveChapterLengthSpec(targetChars?: number): ChapterLengthSpec {
+  const target = Number.isFinite(targetChars) && (targetChars as number) > 0
+    ? Math.max(500, Math.min(20000, Math.round(targetChars as number)))
+    : DEEP_CHAPTER_TARGET_CHARS
+  if (target === DEEP_CHAPTER_TARGET_CHARS) return DEFAULT_CHAPTER_LENGTH_SPEC
+  return {
+    targetChars: target,
+    // 与默认 2200/3000 保持同一比例，最低不少于 300 字
+    minChars: Math.max(300, Math.round(target * (DEEP_CHAPTER_MIN_CHARS / DEEP_CHAPTER_TARGET_CHARS))),
+    draftMaxChars: target + (DEEP_CHAPTER_DRAFT_MAX_CHARS - DEEP_CHAPTER_TARGET_CHARS),
+    // 中文正文约 1-2 token/字，给草稿上限留足输出空间
+    maxOutputTokens: Math.max(DEEP_CHAPTER_MAX_OUTPUT_TOKENS, Math.ceil((target + 500) * 2)),
+  }
+}
+
+function chapterLengthBoundary(lengthSpec: ChapterLengthSpec): string {
+  return `目标约 ${lengthSpec.targetChars} 字；低于 ${lengthSpec.minChars} 字视为正文初稿未完成。`
 }
 
 export function buildDeepChapterBriefPrompt(
@@ -16,6 +46,7 @@ export function buildDeepChapterBriefPrompt(
   userRequest: string,
   chapterNumber?: number,
   goldenThreeChapter?: GoldenThreeChapterRequest,
+  lengthSpec: ChapterLengthSpec = DEFAULT_CHAPTER_LENGTH_SPEC,
 ): string {
   return [
     "你是小说写作任务规划助手。",
@@ -25,7 +56,7 @@ export function buildDeepChapterBriefPrompt(
     "1. 只输出任务书，不要写故事片段。",
     "2. 必须列出本章必须完成、禁止违背、角色状态、伏笔推进、结尾钩子。",
     "3. 如果上下文不足，写明缺失项，并给出最小补全方向。",
-    `4. 后续正文必须按完整章节规划，${chapterLengthBoundary()}`,
+    `4. 后续正文必须按完整章节规划，${chapterLengthBoundary(lengthSpec)}`,
     "5. 任务书必须规划足够的场景推进、冲突升级、人物互动、细节描写和结尾钩子，避免只写一个短场景。",
     "",
     chapterNumber ? `目标章节：第${chapterNumber}章` : "目标章节：用户请求中的章节",
@@ -43,6 +74,7 @@ export function buildDeepChapterDraftPrompt(
   userRequest: string,
   chapterNumber?: number,
   goldenThreeChapter?: GoldenThreeChapterRequest,
+  lengthSpec: ChapterLengthSpec = DEFAULT_CHAPTER_LENGTH_SPEC,
 ): string {
   return [
     "你是专业小说正文写作助手。",
@@ -53,7 +85,7 @@ export function buildDeepChapterDraftPrompt(
     "2. 不要输出分析、任务书、审稿说明、引用来源或后续建议。",
     "3. 严格承接上一章结尾，遵守大纲、记忆、人设、伏笔和时间线。",
     "4. 结尾必须留下适合下一章继续推进的钩子。",
-    `5. 字数必须接近完整章节长度：${chapterLengthBoundary()}阶段3正文草稿最多 ${DEEP_CHAPTER_DRAFT_MAX_CHARS} 字，写到完整结尾后立即停止；不能提前收尾，也不能为了补细节新增额外场景。`,
+    `5. 字数必须接近完整章节长度：${chapterLengthBoundary(lengthSpec)}阶段3正文草稿最多 ${lengthSpec.draftMaxChars} 字，写到完整结尾后立即停止；不能提前收尾，也不能为了补细节新增额外场景。`,
     "6. 必须写成完整章节，不要只写一个片段；需要包含场景铺陈、行动推进、对话交锋、情绪变化、冲突升级和结尾钩子。",
     "7. 禁止复读、循环输出、重复同一段落或用相同句式堆字数；写到完整结尾后立即停止。",
     "",
@@ -115,6 +147,7 @@ export function buildDeepChapterExpansionPrompt(
   userRequest: string,
   chapterNumber?: number,
   goldenThreeChapter?: GoldenThreeChapterRequest,
+  lengthSpec: ChapterLengthSpec = DEFAULT_CHAPTER_LENGTH_SPEC,
 ): string {
   return [
     "你是小说正文扩写补足助手。",
@@ -123,7 +156,7 @@ export function buildDeepChapterExpansionPrompt(
     "硬性要求：",
     "1. 只输出扩写补足后的完整小说正文。",
     "2. 必须保留并自然融合原有正文的有效内容，不要输出解释、分析或修改说明。",
-    `3. ${chapterLengthBoundary()}`,
+    `3. ${chapterLengthBoundary(lengthSpec)}`,
     "4. 扩写时补足场景铺陈、动作细节、对话交锋、心理变化、冲突升级和结尾钩子。",
     "5. 必须严格遵守写作任务书、上下文、人物状态、伏笔和时间线，不要新增会推翻设定的剧情。",
     "6. 禁止复读、循环输出、重复同一段落或用相同句式堆字数；写到完整结尾后立即停止。",

--- a/src/lib/novel/golden-three-chapters.spec.ts
+++ b/src/lib/novel/golden-three-chapters.spec.ts
@@ -52,4 +52,29 @@ describe("golden three chapter constraints", () => {
     expect(result.enabled).toBe(false)
     expect(buildGoldenThreeChapterDirective(result)).toBe("")
   })
+
+  it("prefers the resolved chapter number over incidental 开篇/第一章 wording (issue #9)", () => {
+    const customizedNextChapterPrompt =
+      "请根据当前小说上下文、记忆库、最新章节结尾、下一章推进建议和章纲，继续生成下一章正文。开篇200字内必须制造'钩子'。"
+
+    const chapterFour = detectGoldenThreeChapterRequest(customizedNextChapterPrompt, 4)
+    expect(chapterFour.enabled).toBe(false)
+
+    const chapterTwo = detectGoldenThreeChapterRequest(customizedNextChapterPrompt, 2)
+    expect(chapterTwo.enabled).toBe(true)
+    expect(chapterTwo.targetChapter).toBe(2)
+    expect(chapterTwo.outputMode).toBe("chapter_only")
+  })
+
+  it("does not enable golden constraints from 开篇 writing requirements inside a longer prompt", () => {
+    const result = detectGoldenThreeChapterRequest("继续生成下一章正文，开篇200字内必须制造'钩子'。")
+
+    expect(result.enabled).toBe(false)
+  })
+
+  it("does not enable golden constraints when polishing mentions 开篇", () => {
+    const result = detectGoldenThreeChapterRequest("帮我润色当前章节，开篇要更抓人一些，节奏不要拖。")
+
+    expect(result.enabled).toBe(false)
+  })
 })

--- a/src/lib/novel/golden-three-chapters.ts
+++ b/src/lib/novel/golden-three-chapters.ts
@@ -19,13 +19,13 @@ const firstThreePatterns = [
 ]
 
 const firstChapterPatterns = [
-  /首章/,
   /第一章/,
   /第\s*1\s*章/,
   /开篇章节/,
-  /开篇/,
-  /开局/,
   /小说开头/,
+  // “开篇/开局/首章/开头”属于弱关键词：仅当紧跟写作动词时才视为
+  // “写开篇章节”，避免“开篇200字内必须制造钩子”这类写作要求误触发。
+  /(写|生成|创作|撰写|开始)(一?个)?(小说)?(开篇|开局|首章|开头)/,
 ]
 
 const secondChapterPatterns = [
@@ -43,7 +43,37 @@ export function detectGoldenThreeChapterRequest(text: string, chapterNumber?: nu
   if (!normalized) return disabledGoldenThreeChapterRequest
 
   const requestedFirstThree = firstThreePatterns.some((pattern) => pattern.test(normalized))
-  if (requestedFirstThree || firstChapterPatterns.some((pattern) => pattern.test(normalized)) || chapterNumber === 1) {
+
+  // 已解析出明确目标章节号时，以章节号为准。文本中顺带出现的
+  // “开篇/第一章”字样（例如“开篇200字内必须制造钩子”这类写作要求）
+  // 不再把目标章节改写成第1章（issue #9）。
+  if (typeof chapterNumber === "number" && chapterNumber > 0) {
+    if (chapterNumber === 1) {
+      return {
+        enabled: true,
+        targetChapter: 1,
+        outputMode: "first_chapter_with_directions",
+        requestedFirstThree,
+      }
+    }
+    if (chapterNumber === 2 || chapterNumber === 3) {
+      return {
+        enabled: true,
+        targetChapter: chapterNumber,
+        outputMode: "chapter_only",
+        requestedFirstThree: false,
+      }
+    }
+    return disabledGoldenThreeChapterRequest
+  }
+
+  // “继续生成下一章”类请求：目标章节由章节库/会话状态决定，
+  // 不按文本关键词启用黄金三章。
+  if (/下一章|下1章|下章|新的?一章/.test(normalized.replace(/\s+/g, ""))) {
+    return disabledGoldenThreeChapterRequest
+  }
+
+  if (requestedFirstThree || firstChapterPatterns.some((pattern) => pattern.test(normalized))) {
     return {
       enabled: true,
       targetChapter: 1,
@@ -52,7 +82,7 @@ export function detectGoldenThreeChapterRequest(text: string, chapterNumber?: nu
     }
   }
 
-  if (secondChapterPatterns.some((pattern) => pattern.test(normalized)) || chapterNumber === 2) {
+  if (secondChapterPatterns.some((pattern) => pattern.test(normalized))) {
     return {
       enabled: true,
       targetChapter: 2,
@@ -61,7 +91,7 @@ export function detectGoldenThreeChapterRequest(text: string, chapterNumber?: nu
     }
   }
 
-  if (thirdChapterPatterns.some((pattern) => pattern.test(normalized)) || chapterNumber === 3) {
+  if (thirdChapterPatterns.some((pattern) => pattern.test(normalized))) {
     return {
       enabled: true,
       targetChapter: 3,

--- a/src/lib/novel/review-adapter.spec.ts
+++ b/src/lib/novel/review-adapter.spec.ts
@@ -154,13 +154,14 @@ describe("review-adapter staged review", () => {
   })
   it("passes the provided abort signal into staged review streaming", async () => {
     const controller = new AbortController()
+    const receivedSignals: Array<AbortSignal | undefined> = []
     streamChatMock.mockImplementation(async (
       _config: LlmConfig,
       _messages: Array<{ role: string; content: string }>,
       callbacks: StreamCallbacks,
       signal?: AbortSignal,
     ) => {
-      expect(signal).toBe(controller.signal)
+      receivedSignals.push(signal)
       callbacks.onToken("[]")
       callbacks.onDone()
     })
@@ -174,5 +175,43 @@ describe("review-adapter staged review", () => {
     )
 
     expect(streamChatMock).toHaveBeenCalledTimes(4)
+    // 审稿阶段使用“外部停止信号 + 超时信号”的组合信号；
+    // 外部信号中止后，传入流式审稿的组合信号必须立即中止。
+    for (const signal of receivedSignals) {
+      expect(signal).toBeDefined()
+      expect(signal?.aborted).toBe(false)
+    }
+    controller.abort()
+    for (const signal of receivedSignals) {
+      expect(signal?.aborted).toBe(true)
+    }
+  })
+
+  it("starts the staged review already aborted when the stop signal fired beforehand", async () => {
+    const controller = new AbortController()
+    controller.abort()
+    const receivedSignals: Array<AbortSignal | undefined> = []
+    streamChatMock.mockImplementation(async (
+      _config: LlmConfig,
+      _messages: Array<{ role: string; content: string }>,
+      callbacks: StreamCallbacks,
+      signal?: AbortSignal,
+    ) => {
+      receivedSignals.push(signal)
+      callbacks.onToken("[]")
+      callbacks.onDone()
+    })
+
+    await reviewChapter(
+      "E:/Novel",
+      "测试正文",
+      8,
+      undefined,
+      controller.signal,
+    ).catch(() => undefined)
+
+    for (const signal of receivedSignals) {
+      expect(signal?.aborted).toBe(true)
+    }
   })
 })

--- a/src/lib/novel/review-adapter.ts
+++ b/src/lib/novel/review-adapter.ts
@@ -280,8 +280,15 @@ async function runReviewStage(
 function combineSignals(signalA: AbortSignal, signalB: AbortSignal): AbortSignal {
   const controller = new AbortController()
   const abort = () => controller.abort()
-  signalA.addEventListener("abort", abort, { once: true })
-  signalB.addEventListener("abort", abort, { once: true })
+  for (const signal of [signalA, signalB]) {
+    // 信号在组合前就已经中止时（例如用户在审稿开始前点了停止），
+    // addEventListener 不会再触发，必须立即同步中止组合信号。
+    if (signal.aborted) {
+      controller.abort()
+      return controller.signal
+    }
+    signal.addEventListener("abort", abort, { once: true })
+  }
   return controller.signal
 }
 

--- a/src/lib/novel/task-router.spec.ts
+++ b/src/lib/novel/task-router.spec.ts
@@ -27,4 +27,27 @@ describe("routeTask chapter generation", () => {
     expect(route.intent).toBe("write_chapter")
     expect(route.chapterNumber).toBe(3)
   })
+
+  it("does not hijack a customized next-chapter prompt that mentions 开篇 writing requirements (issue #9)", () => {
+    const route = routeTask(
+      "请根据当前小说上下文、记忆库、最新章节结尾、下一章推进建议和章纲，继续生成下一章正文。只输出可直接保存到章节库的小说正文，不要解释，不要列提纲。正文必须是完整章节，内容要吸引读者，留住读者，目标约 3000 字，建议 2800-3400 字，低于 2600 字视为未完成，开篇200字内必须制造'钩子'。",
+    )
+
+    expect(route.intent).toBe("continue_chapter")
+    expect(route.chapterNumber).toBeUndefined()
+  })
+
+  it("does not treat incidental 第一章 mentions in next-chapter requests as opening requests", () => {
+    const route = routeTask("继续生成下一章正文，不要重复第一章的内容。")
+
+    expect(route.intent).toBe("continue_chapter")
+    expect(route.chapterNumber).toBeUndefined()
+  })
+
+  it("keeps explicit later chapter numbers even when the prompt mentions 开篇 hooks", () => {
+    const route = routeTask("写第5章，开篇要有钩子")
+
+    expect(route.intent).toBe("write_chapter")
+    expect(route.chapterNumber).toBe(5)
+  })
 })

--- a/src/lib/novel/task-router.ts
+++ b/src/lib/novel/task-router.ts
@@ -250,6 +250,10 @@ export function routeTask(userInput: string): TaskRouteResult {
 }
 
 function extractChapterNumber(text: string): number | undefined {
+  // “下一章”类续写请求的目标章节由章节库/会话状态推算，
+  // 文本中顺带提到的其他章节号（如“不要重复第一章内容”）只是引用。
+  if (hasNextChapterContinuationWording(text)) return undefined
+
   const openingChapterNumber = extractOpeningChapterNumber(text)
   if (openingChapterNumber !== undefined) return openingChapterNumber
 
@@ -265,31 +269,62 @@ function extractChapterNumber(text: string): number | undefined {
   return undefined
 }
 
+// “继续生成下一章”类请求：续写语义优先于开篇关键词。
+// 修复 issue #9：自定义下一章提示词中出现“开篇200字内必须制造钩子”
+// 之类的写作要求时，“开篇/第一章”字样不应把目标章节劫持为第1章。
+const NEXT_CHAPTER_CONTINUATION_RE = /下一章|下1章|下章|新的?一章/
+
+function hasNextChapterContinuationWording(text: string): boolean {
+  return NEXT_CHAPTER_CONTINUATION_RE.test(text.replace(/\s+/g, ""))
+}
+
+// 全文出现明确的“第N章”（N>3）时，说明用户的目标章节并非开篇章节，
+// 文本里顺带提到的“开篇/第一章”只是写作要求或剧情引用。
+function hasExplicitLaterChapterNumber(text: string): boolean {
+  const compact = text.replace(/\s+/g, "")
+  const explicit = compact.match(/第(\d+)章/)
+  return Boolean(explicit?.[1] && Number(explicit[1]) > 3)
+}
+
+// “开篇/开局/首章/开头”这类弱关键词：仅当紧跟写作动词，或请求本身
+// 就是一句很短的开篇指令时，才视为“写开篇章节”。避免长提示词里的
+// “开篇200字内必须制造钩子”这类局部写作要求被误判。
+function isAmbientOpeningKeywordRequest(text: string): boolean {
+  const compact = text.replace(/\s+/g, "")
+  if (/(写|生成|创作|撰写|开始)(一?个)?(小说)?(开篇|开局|首章|开头)/.test(compact)) return true
+  return compact.length <= 12 && /开篇|开局|首章|小说开头/.test(compact)
+}
+
 function isOpeningChapterRequest(text: string): boolean {
-  return [
+  if (hasNextChapterContinuationWording(text)) return false
+  if (hasExplicitLaterChapterNumber(text)) return false
+  if ([
     /生成前三章/,
     /写前三章/,
     /黄金三章/,
-    /写?首章/,
     /第一章/,
     /第\s*1\s*章/,
     /开篇章节/,
-    /写?开篇/,
-    /写?开局/,
     /小说开头/,
     /(生成|写|创作|撰写)\s*(第二章|第\s*2\s*章|第\s*二\s*章)/,
     /(生成|写|创作|撰写)\s*(第三章|第\s*3\s*章|第\s*三\s*章)/,
-  ].some((pattern) => pattern.test(text))
+  ].some((pattern) => pattern.test(text))) {
+    return true
+  }
+  return isAmbientOpeningKeywordRequest(text)
 }
 
 function extractOpeningChapterNumber(text: string): number | undefined {
+  if (hasNextChapterContinuationWording(text)) return undefined
+  if (hasExplicitLaterChapterNumber(text)) return undefined
   const digitMatch = text.match(/第\s*([123])\s*章/)
   if (digitMatch) return Number(digitMatch[1])
-  if (/首章|第一章|第\s*1\s*章|开篇章节|写?开篇|写?开局|小说开头|生成前三章|写前三章|黄金三章/.test(text)) {
+  if (/首章|第一章|第\s*1\s*章|开篇章节|小说开头|生成前三章|写前三章|黄金三章/.test(text)) {
     return 1
   }
   if (/第二章|第\s*二\s*章/.test(text)) return 2
   if (/第三章|第\s*三\s*章/.test(text)) return 3
+  if (isAmbientOpeningKeywordRequest(text)) return 1
   return undefined
 }
 

--- a/src/lib/project-store.ts
+++ b/src/lib/project-store.ts
@@ -616,6 +616,7 @@ function normalizeNovelConfig(
     contextTokenBudget: Math.max(0, config.contextTokenBudget ?? DEFAULT_NOVEL_CONFIG.contextTokenBudget),
     recentSummaryWindow: Math.max(1, Math.min(30, config.recentSummaryWindow ?? DEFAULT_NOVEL_CONFIG.recentSummaryWindow)),
     searchTopK: Math.max(1, Math.min(20, config.searchTopK ?? DEFAULT_NOVEL_CONFIG.searchTopK)),
+    chapterTargetChars: Math.max(500, Math.min(20000, config.chapterTargetChars ?? DEFAULT_NOVEL_CONFIG.chapterTargetChars)),
     autoIngestOnSave: config.autoIngestOnSave ?? DEFAULT_NOVEL_CONFIG.autoIngestOnSave,
     autoExtractOnImport: config.autoExtractOnImport ?? DEFAULT_NOVEL_CONFIG.autoExtractOnImport,
     reviewBeforeSave: config.reviewBeforeSave ?? DEFAULT_NOVEL_CONFIG.reviewBeforeSave,

--- a/src/stores/wiki-store.ts
+++ b/src/stores/wiki-store.ts
@@ -250,6 +250,8 @@ export interface NovelConfig {
   contextTokenBudget: number
   recentSummaryWindow: number
   searchTopK: number
+  /** 单章目标字数（按去除空白后的字符数计），章节生成提示词和扩写阈值都按它推算。 */
+  chapterTargetChars: number
   autoIngestOnSave: boolean
   autoExtractOnImport: boolean
   reviewBeforeSave: boolean
@@ -263,6 +265,7 @@ export const DEFAULT_NOVEL_CONFIG: NovelConfig = {
   contextTokenBudget: 0,
   recentSummaryWindow: 8,
   searchTopK: 5,
+  chapterTargetChars: 3000,
   autoIngestOnSave: true,
   autoExtractOnImport: true,
   reviewBeforeSave: false,


### PR DESCRIPTION
1. 修复"继续生成下一章"重复生成第一章（#6 #9）：提示词中顺带出现的 "开篇/第一章/开局"字样不再劫持目标章节；续写语义优先；已解析的 目标章节号优先于文本关键词，目标章节≥4时不再误启黄金三章模式。
2. 继续生成下一章会记住本会话刚生成、尚未保存的章节号，章节库为空时 也能正确推进到下一章，不再回退重写第1章。
3. 修复AI修改章节"返回内容缺少 frontmatter，已停止写回"（#10）：自动 沿用原章节 frontmatter，容错代码围栏、【第N章】标记与缺失标题行。
4. 新增"单章目标字数"设置（#8）：章节生成、扩写阈值、输出token上限 和继续生成下一章提示词都按设置目标推算，默认3000字，按项目持久化。
5. 修复停止信号在审稿开始前已生效时审稿无法停止的问题（combineSignals 不处理已中止信号）。
6. 修复发布分支遗留的10个测试失败：同步31c3417后过时的断言、修正 release-notes.spec.mjs 编码为UTF-8、补齐 changelog 2.2.12 条目。
7. 新增24个回归测试覆盖以上修复场景。

验证：npm run typecheck 通过；npm run test:mocks 62文件/217测试全部通过。