### PR TITLE
feat(format): 一键排版接入 pangu 中英混排空格

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,7 @@ src/test-helpers/*
 **/*.test.ts
 **/*.test.tsx
 !src/lib/chat-copy-content.test.ts
+!src/lib/chapter-formatting.test.ts
 !src/lib/dashboard-issue-actions.test.ts
 !src/lib/tauri-fetch.test.ts
 !src/lib/novel/start-review-run.test.ts

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "qmai",
-  "version": "2.2.37",
+  "version": "3.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "qmai",
-      "version": "2.2.37",
+      "version": "3.0.2",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "@base-ui/react": "^1.6.0",
@@ -39,6 +39,7 @@
         "lucide-react": "^1.23.0",
         "mermaid": "^11.16.0",
         "opencc-js": "^1.4.0",
+        "pangu": "^9.0.0",
         "pinyin-pro": "^3.28.1",
         "react": "^19.2.7",
         "react-dom": "^19.2.7",
@@ -8603,6 +8604,18 @@
       "license": "MIT",
       "dependencies": {
         "mnemonist": "^0.39.2"
+      }
+    },
+    "node_modules/pangu": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/pangu/-/pangu-9.0.0.tgz",
+      "integrity": "sha512-VEkgcpBLXV6anBj/ZOgDhdWtmmewNd5OpJHC9L3Aa6WoLondpPF3uYlpZKBJt9qxv0pj23TB4knaQe+ntTZEYg==",
+      "license": "MIT",
+      "bin": {
+        "pangu": "dist/node/cli.js"
+      },
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/parent-module": {

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "lucide-react": "^1.23.0",
     "mermaid": "^11.16.0",
     "opencc-js": "^1.4.0",
+    "pangu": "^9.0.0",
     "pinyin-pro": "^3.28.1",
     "react": "^19.2.7",
     "react-dom": "^19.2.7",

--- a/src/lib/chapter-formatting.test.ts
+++ b/src/lib/chapter-formatting.test.ts
@@ -1,0 +1,49 @@
+import { expect, test } from "vitest"
+import { formatChapterWriting } from "./chapter-formatting"
+
+test("inserts spaces between CJK and Latin on normal paragraphs", () => {
+  const result = formatChapterWriting("中文English中文")
+
+  expect(result).toBe("　　中文 English 中文")
+})
+
+test("keeps full-width first-line indent", () => {
+  const result = formatChapterWriting("　　纯中文段落")
+
+  expect(result).toBe("　　纯中文段落")
+  expect(result.startsWith("　　")).toBe(true)
+})
+
+test("does not alter fenced code content", () => {
+  const markdown = ["```", "中文English中文", "```"].join("\n")
+  const result = formatChapterWriting(markdown)
+
+  expect(result).toBe(markdown)
+})
+
+test("does not alter structural line text (no pangu spacing)", () => {
+  const markdown = ["# 标题English", "- 列表English", "> 引用English"].join("\n")
+  const result = formatChapterWriting(markdown)
+
+  expect(result).toContain("# 标题English")
+  expect(result).toContain("- 列表English")
+  expect(result).toContain("> 引用English")
+  expect(result).not.toContain("标题 English")
+  expect(result).not.toContain("列表 English")
+  expect(result).not.toContain("引用 English")
+})
+
+test("preserves frontmatter and spaces body prose", () => {
+  const markdown = [
+    "---",
+    "title: 第一章",
+    "---",
+    "",
+    "他说Hello World",
+  ].join("\n")
+
+  const result = formatChapterWriting(markdown)
+
+  expect(result.startsWith("---\ntitle: 第一章\n---\n")).toBe(true)
+  expect(result).toContain("　　他说 Hello World")
+})

--- a/src/lib/chapter-formatting.ts
+++ b/src/lib/chapter-formatting.ts
@@ -1,3 +1,4 @@
+import pangu from "pangu"
 import { parseFrontmatter } from "@/lib/frontmatter"
 
 function isStructuralMarkdownLine(trimmed: string): boolean {
@@ -56,7 +57,8 @@ export function formatChapterWriting(markdown: string): string {
     ) {
       formatted.push("")
     }
-    formatted.push(`　　${trimmed.replace(/^[　 ]+/, "")}`)
+    const content = trimmed.replace(/^[　 ]+/, "")
+    formatted.push(`　　${pangu.spacingText(content)}`)
     pendingBlank = true
     lastKind = "normal"
   }


### PR DESCRIPTION
## Summary
- 引入 `pangu@^9.0.0`，在「一键排版」核心 `formatChapterWriting` 中对普通正文调用 `spacingText`
- 标题 / 列表 / 表格 / 代码围栏 / frontmatter 不改动；仍保留全角首行缩进
- 补充 `chapter-formatting` 单元测试（含 `.gitignore` 白名单）

## 什么是 pangu

[pangu.js](https://github.com/vinta/pangu.js)（盘古之白）是一个中英文混排间距库：在 CJK（中日韩）文字与半角字符（英文、数字、部分符号）之间自动插入空格，提升可读性。

示例：
- `中文English中文` → `中文 English 中文`
- `他说Hello World` → `他说 Hello World`
- `你好123世界` → `你好 123 世界`

本 PR 使用的是 v9 API：`pangu.spacingText(text)`。仅作用于章节正文普通段落，不会改写 Markdown 结构行或代码块。

## Test plan
- [ ] 打开章节 markdown，点击「一键排版」，确认中英/数字混排插入空格（如 `中文English` → `中文 English`）
- [ ] 确认正文仍有 `　　` 首行缩进
- [ ] 确认代码围栏内、标题/列表行不被 pangu 改写
- [ ] `npx vitest run src/lib/chapter-formatting.test.ts` 通过