### PR TITLE
fix(writing): 优先用 field-sizing 避免文章编辑框末尾截断

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -5825,7 +5825,7 @@ checksum = "e0c5ccf5294c6ccd63a74f1565028353830a9c2f5eb0c682c355c471726a6e3f"
 
 [[package]]
 name = "qmai"
-version = "3.0.3"
+version = "3.0.4"
 dependencies = [
  "arrow-array",
  "arrow-schema",

--- a/src/components/editor/wiki-editor.immersive.spec.tsx
+++ b/src/components/editor/wiki-editor.immersive.spec.tsx
@@ -4,7 +4,7 @@ import { act, useState } from "react"
 import { createRoot } from "react-dom/client"
 import { describe, expect, it } from "vitest"
 import { formatChapterWriting } from "@/lib/chapter-formatting"
-import { WikiEditor } from "./wiki-editor"
+import { supportsFieldSizingContent, WikiEditor } from "./wiki-editor"
 
 (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true
 
@@ -42,6 +42,86 @@ describe("WikiEditor immersive writing", () => {
 
     act(() => root.unmount())
     document.body.removeChild(container)
+  })
+
+  it("prefers CSS field-sizing when supported, otherwise keeps JS height sizing", () => {
+    const originalSupports = globalThis.CSS?.supports
+    const cssStub = {
+      supports: (property: string, value?: string) =>
+        property === "field-sizing" && value === "content",
+    }
+    Object.defineProperty(globalThis, "CSS", {
+      configurable: true,
+      writable: true,
+      value: cssStub,
+    })
+    expect(supportsFieldSizingContent()).toBe(true)
+
+    const container = document.createElement("div")
+    document.body.appendChild(container)
+    const root = createRoot(container)
+
+    act(() => {
+      root.render(
+        <WikiEditor
+          content={"# 第1章\n\n这是一段正文。"}
+          onSave={() => {}}
+          immersiveWriting
+        />,
+      )
+    })
+
+    const textarea = container.querySelector("textarea")
+    expect(textarea).not.toBeNull()
+    expect(textarea?.style.fieldSizing).toBe("content")
+
+    act(() => root.unmount())
+    document.body.removeChild(container)
+
+    Object.defineProperty(globalThis, "CSS", {
+      configurable: true,
+      writable: true,
+      value: {
+        supports: () => false,
+      },
+    })
+    expect(supportsFieldSizingContent()).toBe(false)
+
+    const fallbackContainer = document.createElement("div")
+    document.body.appendChild(fallbackContainer)
+    const fallbackRoot = createRoot(fallbackContainer)
+
+    act(() => {
+      fallbackRoot.render(
+        <WikiEditor
+          content={"# 第1章\n\n这是一段正文。"}
+          onSave={() => {}}
+          immersiveWriting
+        />,
+      )
+    })
+
+    const fallbackTextarea = fallbackContainer.querySelector("textarea")
+    expect(fallbackTextarea).not.toBeNull()
+    expect(fallbackTextarea?.style.fieldSizing).toBe("")
+
+    act(() => fallbackRoot.unmount())
+    document.body.removeChild(fallbackContainer)
+
+    if (originalSupports) {
+      Object.defineProperty(globalThis, "CSS", {
+        configurable: true,
+        writable: true,
+        value: { supports: originalSupports },
+      })
+    } else {
+      // jsdom may not define CSS.supports
+      Object.defineProperty(globalThis, "CSS", {
+        configurable: true,
+        writable: true,
+        value: undefined,
+      })
+    }
   })
 
   it("keeps typing on the inserted line after the parent normalizes chapter content", async () => {

--- a/src/components/editor/wiki-editor.tsx
+++ b/src/components/editor/wiki-editor.tsx
@@ -44,6 +44,15 @@ interface WikiEditorInnerProps {
   onSave: (markdown: string) => void;
 }
 
+/** Prefer CSS `field-sizing: content` when available; otherwise JS scrollHeight. */
+export function supportsFieldSizingContent(): boolean {
+  return (
+    typeof CSS !== "undefined" &&
+    typeof CSS.supports === "function" &&
+    CSS.supports("field-sizing", "content")
+  );
+}
+
 interface WritingTextareaProps {
   content: string;
   onSave: (markdown: string) => void;
@@ -95,6 +104,7 @@ const WritingTextarea = forwardRef<WritingTextareaHandle, WritingTextareaProps>(
       () => findAllMatches(value, findQuery, { caseSensitive: false }),
       [value, findQuery],
     );
+    const cssAutoHeight = supportsFieldSizingContent();
 
     useImperativeHandle(
       ref,
@@ -152,6 +162,7 @@ const WritingTextarea = forwardRef<WritingTextareaHandle, WritingTextareaProps>(
 
     const resize = useMemo(
       () => () => {
+        if (cssAutoHeight) return;
         const el = textareaRef.current;
         if (!el) return;
         // 找到外层滚动容器，保存滚动位置防止跳动
@@ -177,14 +188,16 @@ const WritingTextarea = forwardRef<WritingTextareaHandle, WritingTextareaProps>(
           scrollContainer.scrollLeft = savedScrollLeft;
         }
       },
-      [],
+      [cssAutoHeight],
     );
 
     useEffect(() => {
+      if (cssAutoHeight) return;
       resize();
-    }, [value, resize]);
+    }, [value, resize, cssAutoHeight]);
 
     useEffect(() => {
+      if (cssAutoHeight) return;
       const el = textareaRef.current;
       if (!el) return;
       const resizeTarget = el.parentElement ?? el;
@@ -213,7 +226,7 @@ const WritingTextarea = forwardRef<WritingTextareaHandle, WritingTextareaProps>(
         if (frame !== null) cancelAnimationFrame(frame);
         observer.disconnect();
       };
-    }, [resize]);
+    }, [resize, cssAutoHeight]);
 
     const refreshSelection = useCallback(() => {
       const el = textareaRef.current;
@@ -520,6 +533,7 @@ const WritingTextarea = forwardRef<WritingTextareaHandle, WritingTextareaProps>(
               fontFamily: "inherit",
               minHeight: "100%",
               height: "auto",
+              ...(cssAutoHeight ? { fieldSizing: "content" as const } : {}),
             }}
             spellCheck={false}
           />


### PR DESCRIPTION
## Summary
- 章节 immersive 写作框优先使用 CSS `field-sizing: content` 做自适应高度，避免 `scrollHeight` 欠测导致末尾文字被 `overflow-hidden` 裁切
- 浏览器不支持时降级为现有 JS `scrollHeight` + ResizeObserver 逻辑
- 补充 CSS 支持/降级路径的单元测试

## Test plan
- [ ] 在支持 `field-sizing` 的 WebView/浏览器中打开章节写作，长文末尾完整可见
- [ ] 反复调整窗口宽度，换行变化后末尾仍不被截断
- [ ] 确认外层仍只有一条滚动条（textarea 无第二滚动条）
- [ ] `npx vitest run src/components/editor/wiki-editor.immersive.spec.tsx`


Made with [Cursor](https://cursor.com)