### PR TITLE
fix: 重提取记忆时覆盖 tracking 时间线，不再追加重复行

### DIFF
--- a/src/lib/novel/chapter-ingest-extract.spec.ts
+++ b/src/lib/novel/chapter-ingest-extract.spec.ts
@@ -80,6 +80,7 @@ describe("chapter ingest reextract path", () => {
     expect(source).toContain("skipDerivedIncremental: true")
     expect(source).toContain("if (isReingest)")
     expect(source).toContain("await finalizeProjectMemoryRebuild(pp)")
+    expect(source).toContain("await rebuildTimelineFromSnapshots(projectPath, snapshots)")
     expect(source).toContain("if (!isReingest && shouldRebuildCommunitySummaries")
   })
 

--- a/src/lib/novel/chapter-ingest.ts
+++ b/src/lib/novel/chapter-ingest.ts
@@ -28,7 +28,7 @@ import { hasUsableLlm } from "@/lib/has-usable-llm"
 import { shouldRebuildCommunitySummaries, generateCommunitySummaries } from "./community-summary"
 import { buildChapterIngestOutput, type ChapterIngestOutput } from "./chapter-ingest-output"
 import { createChapterPipeline } from "./chapter-pipeline"
-import { mergeSnapshotTimeline } from "./timeline"
+import { mergeSnapshotTimeline, rebuildTimelineFromSnapshots } from "./timeline"
 import { buildStructuredMemoryDocuments, isValidMemorySnapshot } from "./memory-rebuild"
 import { clearGraphCache } from "@/lib/graph-relevance"
 import { RetrievalStore } from "./retrieval"
@@ -1256,6 +1256,7 @@ export async function rebuildDerivedMemoryFromSnapshots(projectPath: string, lat
     applyForeshadowingChangesToStore(foreshadowingStore, snapshot)
   }
   await saveForeshadowingTracker(projectPath, foreshadowingStore)
+  await rebuildTimelineFromSnapshots(projectPath, snapshots)
 
   await writeStructuredMemoryDocuments(projectPath, snapshots)
 }

--- a/src/lib/novel/timeline.spec.ts
+++ b/src/lib/novel/timeline.spec.ts
@@ -1,0 +1,136 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+const memStore = new Map<string, string>()
+
+vi.mock("@/commands/fs", () => ({
+  readFile: vi.fn(async (path: string) => {
+    const content = memStore.get(path)
+    if (content == null) throw new Error("missing")
+    return content
+  }),
+  writeFile: vi.fn(async (path: string, content: string) => {
+    memStore.set(path, content)
+  }),
+}))
+
+import {
+  getTimelineEvents,
+  mergeSnapshotTimeline,
+  rebuildTimelineFromSnapshots,
+  replaceChapterTimelineEntries,
+  timelineEntriesFromSnapshots,
+} from "./timeline"
+
+const projectPath = "E:/Novel"
+const timelinePath = "E:/Novel/.novel/timeline.json"
+
+beforeEach(() => {
+  memStore.clear()
+})
+
+describe("replaceChapterTimelineEntries", () => {
+  it("replaces the chapter instead of appending reworded events", () => {
+    const existing = [
+      { chapterNumber: 239, event: "先遣队抵达边境" },
+      { chapterNumber: 240, event: "当日晚，三处数据链直通节点完成首轮通联测试。" },
+      { chapterNumber: 240, event: "协议落地后第三天，A-50第一次进入叙利亚空域。" },
+    ]
+
+    const next = replaceChapterTimelineEntries(existing, 240, [
+      "数据链通联测试完成",
+      "A-50首次进入叙利亚空域",
+    ])
+
+    expect(next).toEqual([
+      { chapterNumber: 239, event: "先遣队抵达边境" },
+      { chapterNumber: 240, event: "数据链通联测试完成" },
+      { chapterNumber: 240, event: "A-50首次进入叙利亚空域" },
+    ])
+  })
+
+  it("clears the chapter when the new extract has no timeline events", () => {
+    const existing = [
+      { chapterNumber: 1, event: "开场" },
+      { chapterNumber: 2, event: "旧事件" },
+    ]
+    expect(replaceChapterTimelineEntries(existing, 2, [])).toEqual([
+      { chapterNumber: 1, event: "开场" },
+    ])
+  })
+
+  it("drops blank and duplicate events from the same extract", () => {
+    const next = replaceChapterTimelineEntries([], 3, [
+      "  进城  ",
+      "",
+      "进城",
+      "开战",
+    ])
+    expect(next).toEqual([
+      { chapterNumber: 3, event: "进城" },
+      { chapterNumber: 3, event: "开战" },
+    ])
+  })
+})
+
+describe("timelineEntriesFromSnapshots", () => {
+  it("rebuilds the full timeline from current snapshots", () => {
+    const entries = timelineEntriesFromSnapshots([
+      { chapterNumber: 1, timelineEvents: ["开场", "开场"] },
+      { chapterNumber: 2, timelineEvents: ["  进城  ", ""] },
+    ])
+    expect(entries).toEqual([
+      { chapterNumber: 1, event: "开场" },
+      { chapterNumber: 2, event: "进城" },
+    ])
+  })
+})
+
+describe("mergeSnapshotTimeline", () => {
+  it("overwrites the same chapter on reextract instead of appending", async () => {
+    memStore.set(timelinePath, JSON.stringify({
+      version: 1,
+      serial: 2,
+      updatedAt: "",
+      entries: [
+        { chapterNumber: 240, event: "当日晚，三处数据链直通节点完成首轮通联测试。" },
+        { chapterNumber: 240, event: "协议落地后第三天，A-50第一次进入叙利亚空域。" },
+      ],
+    }))
+
+    await mergeSnapshotTimeline(projectPath, 240, [
+      "数据链通联测试完成",
+      "A-50首次进入叙利亚空域",
+    ])
+
+    const events = await getTimelineEvents(projectPath)
+    expect(events).toEqual([
+      { chapterNumber: 240, event: "数据链通联测试完成" },
+      { chapterNumber: 240, event: "A-50首次进入叙利亚空域" },
+    ])
+  })
+})
+
+describe("rebuildTimelineFromSnapshots", () => {
+  it("drops stale chapter events that are no longer in snapshots", async () => {
+    memStore.set(timelinePath, JSON.stringify({
+      version: 1,
+      serial: 3,
+      updatedAt: "",
+      entries: [
+        { chapterNumber: 1, event: "旧开场" },
+        { chapterNumber: 240, event: "旧通联测试" },
+        { chapterNumber: 240, event: "新通联测试" },
+      ],
+    }))
+
+    await rebuildTimelineFromSnapshots(projectPath, [
+      { chapterNumber: 1, timelineEvents: ["开场"] },
+      { chapterNumber: 240, timelineEvents: ["数据链通联测试完成"] },
+    ])
+
+    expect(await getTimelineEvents(projectPath)).toEqual([
+      { chapterNumber: 1, event: "开场" },
+      { chapterNumber: 240, event: "数据链通联测试完成" },
+    ])
+  })
+})

--- a/src/lib/novel/timeline.ts
+++ b/src/lib/novel/timeline.ts
@@ -35,27 +35,65 @@ async function saveTimeline(projectPath: string, data: TimelineFile): Promise<vo
   await writeFile(path, JSON.stringify(data, null, 2))
 }
 
+export function replaceChapterTimelineEntries(
+  entries: TimelineEntry[],
+  chapterNumber: number,
+  timelineEvents: string[] | undefined,
+): TimelineEntry[] {
+  const kept = entries.filter((entry) => entry.chapterNumber !== chapterNumber)
+  const seen = new Set<string>()
+  const next: TimelineEntry[] = []
+  for (const raw of timelineEvents ?? []) {
+    const event = raw.trim()
+    if (!event || seen.has(event)) continue
+    seen.add(event)
+    next.push({ chapterNumber, event })
+  }
+  return [...kept, ...next]
+}
+
+export function timelineEntriesFromSnapshots(
+  snapshots: Array<{ chapterNumber: number; timelineEvents?: string[] }>,
+): TimelineEntry[] {
+  const entries: TimelineEntry[] = []
+  for (const snapshot of snapshots) {
+    const seen = new Set<string>()
+    for (const raw of snapshot.timelineEvents ?? []) {
+      const event = raw.trim()
+      if (!event || seen.has(event)) continue
+      seen.add(event)
+      entries.push({ chapterNumber: snapshot.chapterNumber, event })
+    }
+  }
+  return entries
+}
+
+/**
+ * 用本章最新提取结果覆盖该章时间线，而不是按原文去重后追加。
+ * 重新提取时措辞会变，追加会留下重复行。
+ */
 export async function mergeSnapshotTimeline(
   projectPath: string,
   chapterNumber: number,
   timelineEvents: string[],
 ): Promise<void> {
-  if (!timelineEvents || timelineEvents.length === 0) return
-
   const tl = await loadTimeline(projectPath)
-
-  const existing = new Set(tl.entries.map((e) => `${e.chapterNumber}:${e.event}`))
-
-  for (const event of timelineEvents) {
-    const key = `${chapterNumber}:${event}`
-    if (!existing.has(key)) {
-      tl.serial++
-      tl.entries.push({ chapterNumber, event })
-      existing.add(key)
-    }
-  }
-
+  tl.entries = replaceChapterTimelineEntries(tl.entries, chapterNumber, timelineEvents)
+  tl.serial = tl.entries.length
   await saveTimeline(projectPath, tl)
+}
+
+export async function rebuildTimelineFromSnapshots(
+  projectPath: string,
+  snapshots: Array<{ chapterNumber: number; timelineEvents?: string[] }>,
+): Promise<void> {
+  const entries = timelineEntriesFromSnapshots(snapshots)
+  await saveTimeline(projectPath, {
+    version: 1,
+    entries,
+    serial: entries.length,
+    updatedAt: "",
+  })
 }
 
 export async function getTimelineEvents(


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 问题

重新提取章节记忆时，`wiki/tracking/时间线.md`（UI 里显示为 `QM/tracking`）不会覆盖该章旧事件，而是把新提取的句子追加在文件末尾。同一章、同一批事件只要措辞稍变，就会留下两套重复行。

根因：`mergeSnapshotTimeline` 按「章节号 + 原文」去重后 `push`。重提取几乎必然改写措辞，去重失效。`时间线.md` 是这份 JSON 的完整转储，所以看起来像「只追加、不覆盖」。角色状态 / 伏笔在重提取时会从快照全量重建，时间线没有走这条路径。

## 修复

- 写入本章时间线时，先删掉该章全部旧事件，再用本次提取结果覆盖（空结果会清空该章）
- 重提取触发的派生记忆重建会从当前全部快照重写 `timeline.json`，清掉历史堆出来的重复行
- 随后 `updateTrackingAfterChapter` 仍会整文件重写 `时间线.md`

## 验证

`npx vitest run src/lib/novel/timeline.spec.ts src/lib/novel/chapter-ingest-extract.spec.ts src/lib/novel/chapter-ingest.spec.ts` — 17 passed

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bab08b9e-d3d1-43bf-914e-5ad7ac31827b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bab08b9e-d3d1-43bf-914e-5ad7ac31827b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

