### PR TITLE
release: 升级版本至 3.2.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "qmai",
-  "version": "3.2.1",
+  "version": "3.2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "qmai",
-      "version": "3.2.1",
+      "version": "3.2.2",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "@base-ui/react": "^1.7.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "qmai",
   "private": true,
-  "version": "3.2.1",
+  "version": "3.2.2",
   "license": "GPL-3.0-or-later",
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -5793,7 +5793,7 @@ checksum = "d55d956fa96f5ec02be2e13af0e20391a5aa83d6a074e3ad368959d0fab299ea"
 
 [[package]]
 name = "qmai"
-version = "3.2.1"
+version = "3.2.2"
 dependencies = [
  "arrow-array",
  "arrow-schema",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "qmai"
-version = "3.2.1"
+version = "3.2.2"
 description = "QMAI - AI writing system for long-form novels"
 authors = ["Mochocyang"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "QMaiWrite",
-  "version": "3.2.1",
+  "version": "3.2.2",
   "identifier": "com.qingmuai.writer",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/src/lib/changelog.spec.ts
+++ b/src/lib/changelog.spec.ts
@@ -6,7 +6,7 @@ describe("changelog", () => {
     const entries = allChangelog()
     const versions = entries.map((entry) => entry.version)
 
-    expect(versions.slice(0, 3)).toEqual(["3.2.1", "3.2.0", "3.1.9"])
+    expect(versions.slice(0, 3)).toEqual(["3.2.2", "3.2.1", "3.2.0"])
     expect(versions).toContain("3.0.9")
     expect(versions).toContain("2.2.37")
     expect(versions).toContain("2.1.0")

--- a/src/lib/changelog.ts
+++ b/src/lib/changelog.ts
@@ -7,6 +7,23 @@ export interface ChangelogEntry {
   };
 }
 
+const THREE_POINT_TWO_TWO_CHANGELOG: ChangelogEntry = {
+  version: "3.2.2",
+  date: "2026-08-15",
+  highlights: {
+    en: [
+      "[Qwen3.5/3.6 Ollama 500 Fix] Extra system messages for Qwen3.5/3.6 are merged into the first one, so local Ollama chapter writing and outline generation no longer fail with HTTP 500 (System message must be at the beginning).",
+      "[Re-extract Overwrites Timeline] Re-extracting chapter memory now replaces that chapter's tracking timeline instead of appending, so the same events no longer pile up as duplicate rows.",
+      "[Faster Chapter Memory Extract] Chapter ingest uses fewer tokens and skips duplicate wiki/snapshot writes; re-extract rebuilds derived memory from snapshots instead of stacking old foreshadowing and cognition.",
+    ],
+    zh: [
+      "【Qwen3.5/3.6 Ollama 500 修复】本地 Ollama 用 Qwen3.5/3.6 写章节或大纲时，多余的 system 会合到第一条，不再报 HTTP 500（System message must be at the beginning）",
+      "【重提取覆盖时间线】重新提取章节记忆时，该章 tracking 时间线改为覆盖而不是追加，同一批事件不会再堆出重复行",
+      "【章节记忆提取更快】摄取少耗 token、去掉重复写入；重提取从快照重建派生记忆，不再把旧认知/伏笔叠进去",
+    ],
+  },
+};
+
 const THREE_POINT_TWO_ONE_CHANGELOG: ChangelogEntry = {
   version: "3.2.1",
   date: "2026-08-14",
@@ -1178,6 +1195,7 @@ function isMergedOnePointRelease(version: string): boolean {
 }
 
 export const CHANGELOG: ChangelogEntry[] = [
+  THREE_POINT_TWO_TWO_CHANGELOG,
   THREE_POINT_TWO_ONE_CHANGELOG,
   THREE_POINT_TWO_ZERO_CHANGELOG,
   THREE_POINT_ONE_NINE_CHANGELOG,
@@ -1245,6 +1263,8 @@ export const CHANGELOG: ChangelogEntry[] = [
 ];
 
 export function currentVersionChangelog(version: string): ChangelogEntry[] {
+  if (version === THREE_POINT_TWO_TWO_CHANGELOG.version)
+    return [THREE_POINT_TWO_TWO_CHANGELOG];
   if (version === THREE_POINT_TWO_ONE_CHANGELOG.version)
     return [THREE_POINT_TWO_ONE_CHANGELOG];
   if (version === THREE_POINT_TWO_ZERO_CHANGELOG.version)
@@ -1352,6 +1372,7 @@ export function currentVersionChangelog(version: string): ChangelogEntry[] {
 
 export function allChangelog(): ChangelogEntry[] {
   return [
+    THREE_POINT_TWO_TWO_CHANGELOG,
     THREE_POINT_TWO_ONE_CHANGELOG,
     THREE_POINT_TWO_ZERO_CHANGELOG,
     THREE_POINT_ONE_NINE_CHANGELOG,
@@ -1404,6 +1425,7 @@ export function allChangelog(): ChangelogEntry[] {
     TWO_POINT_ZERO_CHANGELOG,
     ...CHANGELOG.filter(
       (entry) =>
+        entry !== THREE_POINT_TWO_TWO_CHANGELOG &&
         entry !== THREE_POINT_TWO_ONE_CHANGELOG &&
         entry !== THREE_POINT_TWO_ZERO_CHANGELOG &&
         entry !== THREE_POINT_ONE_NINE_CHANGELOG &&


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
将版本升级到 3.2.2，收录 3.2.1 之后已合入的用户可见改动。GitHub Release 已发布，全平台安装包已上传：[v3.2.2](https://github.com/Mochocyang/QMAI/releases/tag/v3.2.2)。

## 版本号

同步更新：

- `package.json` / `package-lock.json`
- `src-tauri/Cargo.toml` / `src-tauri/Cargo.lock`
- `src-tauri/tauri.conf.json`

## 更新日志（3.2.2）

1. 【Qwen3.5/3.6 Ollama 500 修复】本地 Ollama 用 Qwen3.5/3.6 写章节或大纲时，多余的 system 会合到第一条，不再报 HTTP 500（System message must be at the beginning）（#59）
2. 【重提取覆盖时间线】重新提取章节记忆时，该章 tracking 时间线改为覆盖而不是追加，同一批事件不会再堆出重复行（#57）
3. 【章节记忆提取更快】摄取少耗 token、去掉重复写入；重提取从快照重建派生记忆，不再把旧认知/伏笔叠进去（#55）

## CI

Windows 第一次打包因 Chocolatey 源 504、`choco install protoc` 静默失败而挂掉。已改为 `arduino/setup-protoc@v3`，并在 `gh release edit` 时带 `--draft=false`。当前 Release 资产：Windows 安装包 / 便携版 / 签名、macOS Apple Silicon + Intel、Linux deb + AppImage、`latest.json`。

合入本 PR 后 main 与已发布的 3.2.2 对齐。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-616c9e68-1311-4404-af48-aec42f873763?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-616c9e68-1311-4404-af48-aec42f873763&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

