### PR TITLE
ci: prerelease 分支只打 Windows 内测安装包

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -1,0 +1,161 @@
+name: Windows Prerelease
+
+# 推送到 prerelease 分支时，只打 Windows x64 内测安装包（NSIS + 便携版），
+# 发布为 GitHub prerelease（tag: prerelease）。
+# 不上传 latest.json，正式版自动更新通道不受影响。
+#
+# 首次启用（workflow 合入 main 之后）：
+#   git fetch origin
+#   git push origin origin/main:prerelease
+# 之后把要内测的提交推进 prerelease 即可。
+
+on:
+  push:
+    branches:
+      - prerelease
+  workflow_dispatch:
+
+concurrency:
+  group: windows-prerelease
+  cancel-in-progress: true
+
+permissions:
+  contents: write
+
+jobs:
+  build-windows-prerelease:
+    name: Build Windows x64 内测包
+    runs-on: windows-latest
+    env:
+      CARGO_PROFILE_RELEASE_LTO: "false"
+      CARGO_PROFILE_RELEASE_CODEGEN_UNITS: "16"
+      CARGO_PROFILE_RELEASE_OPT_LEVEL: "1"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Install Rust stable
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Rust cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: src-tauri
+          shared-key: qmai-release
+          add-job-id-key: false
+          cache-on-failure: true
+
+      - name: Install protoc (Windows)
+        uses: arduino/setup-protoc@v3
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: 24
+          cache: npm
+
+      - name: Install frontend dependencies
+        run: npm ci
+
+      - name: Prepare release notes
+        shell: bash
+        run: |
+          set -euo pipefail
+          version="$(node -p "require('./package.json').version")"
+          mkdir -p release-assets
+          node scripts/release-notes.mjs "$version" --out release-assets/changelog.txt
+          sha="$(echo "${GITHUB_SHA}" | cut -c1-7)"
+          {
+            echo "QMAI ${version} Windows 内测包"
+            echo
+            echo "- 平台：Windows x64（不含 macOS / Linux）"
+            echo "- 提交：${GITHUB_SHA}"
+            echo "- 短哈希：${sha}"
+            echo "- 来源：\`${GITHUB_REF_NAME}\`"
+            echo
+            echo "本发布为内测，不会标记为 Latest，也不会写入正式版自动更新通道（latest.json）。"
+            echo
+            echo "## 更新说明"
+            echo
+            cat release-assets/changelog.txt
+          } > release-assets/prerelease-notes.txt
+
+      - name: Build Tauri NSIS installer
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
+        run: npx tauri build --bundles nsis
+
+      - name: Package Windows 内测 assets
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = "Stop"
+          $version = node -p "require('./package.json').version"
+          $sha = "${{ github.sha }}".Substring(0, 7)
+          $assetDir = "release-assets"
+          New-Item -ItemType Directory -Force -Path $assetDir | Out-Null
+
+          $bundleDir = "src-tauri/target/release/bundle/nsis"
+          $installer = Get-ChildItem $bundleDir -File -Filter "*.exe" |
+            Sort-Object LastWriteTime -Descending |
+            Select-Object -First 1
+          if (-not $installer) {
+            throw "未找到 Windows 安装包"
+          }
+          $installerName = "QMaiWrite_${version}_windows_X64_prerelease.exe"
+          Copy-Item $installer.FullName (Join-Path $assetDir $installerName) -Force
+
+          node scripts/build-portable.mjs
+          $portableExe = "release-portable/QMaiWrite.exe"
+          if (-not (Test-Path $portableExe)) {
+            throw "便携版 EXE 未生成：$portableExe"
+          }
+          $portableName = "QMaiWrite_${version}_windows_X64_portable_prerelease.exe"
+          Copy-Item $portableExe (Join-Path $assetDir $portableName) -Force
+
+          Write-Host "sha=$sha"
+          Get-ChildItem $assetDir | Format-Table Name, Length -AutoSize
+
+      - name: Publish GitHub prerelease
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          tag="prerelease"
+          notes="release-assets/prerelease-notes.txt"
+          version="$(node -p "require('./package.json').version")"
+          sha="$(echo "${GITHUB_SHA}" | cut -c1-7)"
+          title="QMAI ${version} 内测 (Windows ${sha})"
+
+          if gh release view "$tag" >/dev/null 2>&1; then
+            gh release delete "$tag" --yes --cleanup-tag
+          fi
+
+          shopt -s nullglob
+          assets=(release-assets/QMaiWrite_*_prerelease.exe)
+          if [ "${#assets[@]}" -eq 0 ]; then
+            echo "未找到 Windows 内测安装包" >&2
+            exit 1
+          fi
+
+          gh release create "$tag" \
+            --title "$title" \
+            --notes-file "$notes" \
+            --prerelease \
+            --latest=false \
+            --target "${GITHUB_SHA}" \
+            "${assets[@]}"
+
+      - name: Upload workflow artifacts
+        uses: actions/upload-artifact@v6
+        with:
+          name: qmai-windows-x64-prerelease
+          path: |
+            release-assets/QMaiWrite_*_prerelease.exe
+            release-assets/prerelease-notes.txt
+          if-no-files-found: error
+          retention-days: 14

--- a/scripts/prerelease-workflow.spec.mjs
+++ b/scripts/prerelease-workflow.spec.mjs
@@ -1,0 +1,29 @@
+import { readFileSync } from "node:fs"
+import { describe, expect, it } from "vitest"
+
+const workflow = readFileSync(".github/workflows/prerelease.yml", "utf8")
+const official = readFileSync(".github/workflows/build.yml", "utf8")
+
+describe("Windows prerelease workflow", () => {
+  it("only runs on the prerelease branch or manual dispatch", () => {
+    expect(workflow).toMatch(/branches:\s*\n\s+- prerelease/)
+    expect(workflow).toContain("workflow_dispatch:")
+    expect(workflow).not.toMatch(/tags:\s*\n\s+- ["']v\*/)
+  })
+
+  it("builds Windows only", () => {
+    expect(workflow).toContain("runs-on: windows-latest")
+    expect(workflow).toContain("--bundles nsis")
+    expect(workflow).not.toMatch(/macos-latest|macos-15-intel|ubuntu-22\.04/)
+    expect(workflow).not.toMatch(/--bundles dmg|--bundles deb/)
+  })
+
+  it("publishes a GitHub prerelease without touching the stable updater channel", () => {
+    expect(workflow).toContain("--prerelease")
+    expect(workflow).toContain("--latest=false")
+    expect(workflow).toContain('tag="prerelease"')
+    expect(workflow).toContain("QMaiWrite_*_prerelease.exe")
+    expect(workflow).not.toMatch(/gh release (create|upload)[\s\S]*latest\.json/)
+    expect(official).toMatch(/gh release upload[\s\S]*latestPath/)
+  })
+})


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
推送到 `prerelease` 只打包 Windows x64 内测安装包，发布为 GitHub prerelease，不进入正式版自动更新通道。

## 行为

- 触发：`push` 到 `prerelease`，或手动 `workflow_dispatch`
- 只跑 `windows-latest`：NSIS 安装包 + 便携版
- 发布固定 tag `prerelease`（`--prerelease --latest=false`），每次覆盖为当前提交
- **不上传** `latest.json`，正式版 `/releases/latest` 更新通道不变
- 产物名：`QMaiWrite_<version>_windows_X64_prerelease.exe` 与 `..._portable_prerelease.exe`

## 启用

`prerelease` 分支已创建。合入 main 后保持它与 main 同步：

```bash
git fetch origin
git checkout prerelease
git merge origin/main
git push origin prerelease
```

安装包：https://github.com/Mochocyang/QMAI/releases/tag/prerelease

## 验证

- YAML 可解析；`scripts/prerelease-workflow.spec.mjs` 通过
- 已在 `prerelease` 分支跑通 [Windows Prerelease](https://github.com/Mochocyang/QMAI/actions/runs/31926254692)（7m12s）
- 已发布 GitHub prerelease `prerelease`：仅 Windows NSIS + 便携版，无 macOS/Linux，无 `latest.json`
- 正式版 Latest 仍是 `v3.2.2`，`latest.json` 未被动过
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a008c3-c9f0-748e-ac89-7de7a958993e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a008c3-c9f0-748e-ac89-7de7a958993e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

