### PR TITLE
fix(chat): 快速模式对话使用所选写作模型

### DIFF
--- a/src/hooks/use-agent-config.spec.ts
+++ b/src/hooks/use-agent-config.spec.ts
@@ -361,6 +361,42 @@ describe("useAgentConfig", () => {
     await cleanup()
   }, 15000)
 
+  it("uses the selected chat model for fast-mode conversation output instead of the default agent model", async () => {
+    const providerConfigs: ProviderConfigs = {
+      custom: {
+        enabled: true,
+        apiKey: "test-key",
+        savedModels: [
+          { id: "writer", name: "Writer", model: "writer-model", createdAt: 1 },
+          { id: "workflow", name: "Workflow", model: "workflow-model", createdAt: 2 },
+        ],
+      },
+    }
+    const { result, cleanup } = await renderHook("test prompt", {
+      wiki: {
+        aiChatModel: "custom/writer-model",
+        defaultLlmModel: "custom/workflow-model",
+        novelConfig: { ...DEFAULT_NOVEL_CONFIG, defaultLlmModel: "custom/workflow-model" },
+        providerConfigs,
+        project: { path: "/tmp/project" } as WikiProject,
+        aiWorkflowMode: "fast",
+      },
+      skillConfig: {
+        version: 1,
+        defaultSkillId: "built-in:comprehensive",
+        disabledSkillIds: [],
+        projectSkills: [],
+        builtInSkillOverrides: [],
+        lastChapterDeAiSkillId: null,
+      },
+    })
+
+    expect(result.config?.modelId).toBe("writer-model")
+    expect(result.config?.llmConfig.model).toBe("writer-model")
+
+    await cleanup()
+  }, 15000)
+
   it("passes Web Search settings into the web_search agent tool", async () => {
     webSearchMock.mockResolvedValueOnce([])
     const searchApiConfig: SearchApiConfig = {

--- a/src/hooks/use-agent-config.ts
+++ b/src/hooks/use-agent-config.ts
@@ -5,7 +5,7 @@ import { useOutlineChatStore } from "@/stores/outline-chat-store"
 import { loadDeAiSkillConfig, type DeAiSkillConfig } from "@/lib/novel/de-ai-skill-library"
 import { loadAllLinkedSkillsContent, loadUserSkillConfig, resolveEnabledWritingSkills } from "@/lib/novel/user-skill-store"
 import type { UserSkill } from "@/lib/novel/skill-library"
-import { resolveDefaultModel, resolveModelConfig } from "@/lib/novel/model-resolver"
+import { resolveAgentSessionModel, resolveModelConfig } from "@/lib/novel/model-resolver"
 import { runDeepChapterGeneration } from "@/lib/novel/deep-chapter-generation"
 import { normalizePath } from "@/lib/path-utils"
 import { ToolRegistry } from "@/lib/agent/registry"
@@ -29,7 +29,7 @@ export interface UseAgentConfigResult {
 export function useAgentConfig(systemPrompt: string, getPlanBlueprint?: () => string | undefined): UseAgentConfigResult {
   const aiChatModel = useWikiStore((s) => s.aiChatModel)
   const defaultLlmModel = useWikiStore((s) => s.defaultLlmModel)
-  const novelDefaultLlmModel = useWikiStore((s) => s.novelConfig.defaultLlmModel)
+  const novelConfig = useWikiStore((s) => s.novelConfig)
   const projectPath = useWikiStore((s) => s.project?.path)
   const dataVersion = useWikiStore((s) => s.dataVersion)
   const baseLlmConfig = useWikiStore((s) => s.llmConfig)
@@ -110,7 +110,7 @@ export function useAgentConfig(systemPrompt: string, getPlanBlueprint?: () => st
   )
 
   return useMemo(() => {
-    const agentLlmConfig = resolveDefaultModel(baseLlmConfig)
+    const agentLlmConfig = resolveAgentSessionModel(baseLlmConfig, novelConfig, aiWorkflowMode)
     const modelOk = modelSupportsTools(agentLlmConfig.model, agentLlmConfig.provider)
     const fcEnabled = isFunctionCallingEnabled(agentLlmConfig)
     const supportsTools = modelOk && fcEnabled
@@ -171,7 +171,7 @@ export function useAgentConfig(systemPrompt: string, getPlanBlueprint?: () => st
   }, [
     aiChatModel,
     defaultLlmModel,
-    novelDefaultLlmModel,
+    novelConfig,
     projectPath,
     skillConfigLoaded,
     baseLlmConfig,

--- a/src/lib/agent/tools/index.ts
+++ b/src/lib/agent/tools/index.ts
@@ -59,7 +59,7 @@ export interface ToolFactoryOptions {
   enabledToolNames?: string[]
   disabledTools?: string[]
   llmConfig?: LlmConfig
-  /** 章节正文专用模型。Agent 调度可使用默认模型，但正文仍必须使用聊天框模型。 */
+  /** 章节正文专用模型。Agent 调度可使用默认模型，但正文仍必须使用聊天框模型。快速模式主 Agent 直接出稿，会话模型与此相同。 */
   chapterWritingLlmConfig?: LlmConfig
   aiWorkflowMode?: AiWorkflowMode
   runDeepChapterGeneration?: RunDeepChapterGeneration

--- a/src/lib/changelog.ts
+++ b/src/lib/changelog.ts
@@ -15,13 +15,11 @@ const THREE_POINT_TWO_TWO_CHANGELOG: ChangelogEntry = {
       "[Qwen3.5/3.6 Ollama 500 Fix] Extra system messages for Qwen3.5/3.6 are merged into the first one, so local Ollama chapter writing and outline generation no longer fail with HTTP 500 (System message must be at the beginning).",
       "[Re-extract Overwrites Timeline] Re-extracting chapter memory now replaces that chapter's tracking timeline instead of appending, so the same events no longer pile up as duplicate rows.",
       "[Faster Chapter Memory Extract] Chapter ingest uses fewer tokens and skips duplicate wiki/snapshot writes; re-extract rebuilds derived memory from snapshots instead of stacking old foreshadowing and cognition.",
-      "[Fast Writing Uses Selected Model] Fast-mode chat/output now uses the writing model selected in the chat picker, not the default main-agent orchestration model.",
     ],
     zh: [
       "【Qwen3.5/3.6 Ollama 500 修复】本地 Ollama 用 Qwen3.5/3.6 写章节或大纲时，多余的 system 会合到第一条，不再报 HTTP 500（System message must be at the beginning）",
       "【重提取覆盖时间线】重新提取章节记忆时，该章 tracking 时间线改为覆盖而不是追加，同一批事件不会再堆出重复行",
       "【章节记忆提取更快】摄取少耗 token、去掉重复写入；重提取从快照重建派生记忆，不再把旧认知/伏笔叠进去",
-      "【快速写作用所选模型】快速模式下对话/出稿改用聊天框选中的写作模型，不再误用默认主 Agent 编排模型",
     ],
   },
 };

--- a/src/lib/changelog.ts
+++ b/src/lib/changelog.ts
@@ -15,11 +15,13 @@ const THREE_POINT_TWO_TWO_CHANGELOG: ChangelogEntry = {
       "[Qwen3.5/3.6 Ollama 500 Fix] Extra system messages for Qwen3.5/3.6 are merged into the first one, so local Ollama chapter writing and outline generation no longer fail with HTTP 500 (System message must be at the beginning).",
       "[Re-extract Overwrites Timeline] Re-extracting chapter memory now replaces that chapter's tracking timeline instead of appending, so the same events no longer pile up as duplicate rows.",
       "[Faster Chapter Memory Extract] Chapter ingest uses fewer tokens and skips duplicate wiki/snapshot writes; re-extract rebuilds derived memory from snapshots instead of stacking old foreshadowing and cognition.",
+      "[Fast Writing Uses Selected Model] Fast-mode chat/output now uses the writing model selected in the chat picker, not the default main-agent orchestration model.",
     ],
     zh: [
       "【Qwen3.5/3.6 Ollama 500 修复】本地 Ollama 用 Qwen3.5/3.6 写章节或大纲时，多余的 system 会合到第一条，不再报 HTTP 500（System message must be at the beginning）",
       "【重提取覆盖时间线】重新提取章节记忆时，该章 tracking 时间线改为覆盖而不是追加，同一批事件不会再堆出重复行",
       "【章节记忆提取更快】摄取少耗 token、去掉重复写入；重提取从快照重建派生记忆，不再把旧认知/伏笔叠进去",
+      "【快速写作用所选模型】快速模式下对话/出稿改用聊天框选中的写作模型，不再误用默认主 Agent 编排模型",
     ],
   },
 };

--- a/src/lib/novel/mod.ts
+++ b/src/lib/novel/mod.ts
@@ -6,7 +6,7 @@ export { buildContextPack, contextPackToPrompt, type ContextPack } from "./conte
 export { ingestChapter, ingestChapterPipeline, ingestOutline, loadSnapshot, listSnapshots, deleteChapterSnapshots, finalizeProjectMemoryRebuild, syncSnapshotToMemory, type ChapterSnapshot, type CharacterDetail, type LocationDetail, type OrganizationDetail, type ItemDetail, type EventDetail, type IngestResult, type IngestFailReason, type OutlineIngestResult, type IngestOutlineOptions, type SyncSnapshotToMemoryOptions } from "./chapter-ingest"
 export { reviewChapter, type NovelReviewResult } from "./review-adapter"
 export { runNovelLint, buildNovelLintPrompt, type NovelLintResult } from "./lint"
-export { resolveNovelModel, type NovelTaskType } from "./model-resolver"
+export { resolveNovelModel, resolveAgentSessionModel, type NovelTaskType } from "./model-resolver"
 export { resolveReviewModel } from "./review-model"
 export { novelMixedSearch, searchPlot, type NovelSearchParams, type NovelSearchResult } from "./search-adapter"
 export { PROMPTS } from "./prompt-templates"

--- a/src/lib/novel/model-resolver.spec.ts
+++ b/src/lib/novel/model-resolver.spec.ts
@@ -1,0 +1,49 @@
+import { afterEach, describe, expect, it } from "vitest"
+import { DEFAULT_NOVEL_CONFIG, useWikiStore, type LlmConfig, type ProviderConfigs } from "@/stores/wiki-store"
+import { resolveAgentSessionModel } from "./model-resolver"
+
+const baseConfig: LlmConfig = {
+  provider: "custom",
+  apiKey: "test-key",
+  model: "",
+  ollamaUrl: "",
+  customEndpoint: "https://example.test/v1",
+  maxContextSize: 8192,
+}
+
+const providerConfigs: ProviderConfigs = {
+  custom: {
+    enabled: true,
+    apiKey: "test-key",
+    savedModels: [
+      { id: "writer", name: "Writer", model: "writer-model", createdAt: 1 },
+      { id: "workflow", name: "Workflow", model: "workflow-model", createdAt: 2 },
+    ],
+  },
+}
+
+describe("resolveAgentSessionModel", () => {
+  afterEach(() => {
+    useWikiStore.setState({
+      aiChatModel: "",
+      defaultLlmModel: "",
+      providerConfigs: {},
+      novelConfig: { ...DEFAULT_NOVEL_CONFIG },
+    })
+  })
+
+  it("uses the selected chat model in fast mode instead of the default orchestration model", () => {
+    const previous = useWikiStore.getState()
+    useWikiStore.setState({
+      aiChatModel: "custom/writer-model",
+      defaultLlmModel: "custom/workflow-model",
+      providerConfigs,
+      novelConfig: { ...previous.novelConfig, defaultLlmModel: "custom/workflow-model" },
+    })
+
+    const novelConfig = useWikiStore.getState().novelConfig
+    expect(resolveAgentSessionModel(baseConfig, novelConfig, "fast").model).toBe("writer-model")
+    expect(resolveAgentSessionModel(baseConfig, novelConfig, "standard").model).toBe("workflow-model")
+    expect(resolveAgentSessionModel(baseConfig, novelConfig, "strict").model).toBe("workflow-model")
+  })
+})

--- a/src/lib/novel/model-resolver.ts
+++ b/src/lib/novel/model-resolver.ts
@@ -5,6 +5,7 @@ import { hasUsableLlm } from "@/lib/has-usable-llm"
 import { getEffectiveMaxContextSize, getEffectiveMaxOutputTokens } from "@/lib/llm-providers"
 import { getStableAvailableModelKey, getEffectiveSavedModels } from "@/lib/llm-model-keys"
 import { normalizeUserLlmConfig } from "@/lib/llm-context-size"
+import type { AiWorkflowMode } from "@/lib/agent/workflow-mode"
 
 export type NovelTaskType = "writing" | "review" | "summary" | "extract" | "lint" | "deAi"
 
@@ -188,6 +189,22 @@ export function resolveNovelModel(
   }
 
   return toUnusableConfig(llmConfig)
+}
+
+/**
+ * 解析 AI 会话主 Agent 使用的模型。
+ * 快速模式像普通对话/大纲绘制一样由主 Agent 直接出稿，必须用聊天框选中的写作模型。
+ * 标准/严格模式主 Agent 只负责编排，继续用默认模型；正文由 chapterWritingLlmConfig 走聊天模型。
+ */
+export function resolveAgentSessionModel(
+  baseConfig: LlmConfig,
+  novelConfig: NovelConfig,
+  workflowMode: AiWorkflowMode,
+): LlmConfig {
+  if (workflowMode === "fast") {
+    return resolveNovelModel(baseConfig, novelConfig, "writing")
+  }
+  return resolveDefaultModel(baseConfig)
 }
 
 export function formatResolvedModelLabel(


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 问题

快速写作时，对话/出稿没有用聊天框选中的模型，而是走了默认主 Agent 编排模型。大纲绘制已经按所选模型出稿，快速写作应对齐同一行为。

快速模式由主 Agent 直接写正文（不走 `run_chapter_workflow`），因此编排模型和写作模型必须是同一个：聊天框里选中的写作模型。

## 改动

- 新增 `resolveAgentSessionModel()`：快速模式用 `resolveNovelModel(..., "writing")`（聊天模型优先），标准/严格模式仍用默认模型做编排
- `useAgentConfig` 的主 Agent 会话配置改走该解析逻辑；章节工作流正文仍用 `chapterWritingLlmConfig`
- 补测试覆盖快速 vs 标准/严格的模型分流
- 不改已发布的 3.2.2 changelog；这条修复等下次发版再记

## 测试

已跑通：

- `src/lib/novel/model-resolver.spec.ts`：fast → `writer-model`，standard/strict → `workflow-model`
- `src/hooks/use-agent-config.spec.ts`：快速模式主 Agent 用聊天模型；标准模式编排仍用默认模型、正文走聊天模型
- `src/lib/changelog.spec.ts` / `src/lib/agent/tools/index.spec.ts` / `src/lib/agent/ai-chat-workflow-convergence.spec.ts`

20 个相关测试全部通过。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a008c7-1908-7c01-93d5-3040aa56eb36?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a008c7-1908-7c01-93d5-3040aa56eb36&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

