### PR TITLE
ci: 前端合进 main 不再跑三平台 release 预热

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,17 +10,18 @@ on:
 jobs:
   changes:
     name: Detect changes
-    if: github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-22.04
     outputs:
       rust: ${{ github.event_name == 'workflow_dispatch' && 'true' || steps.filter.outputs.rust }}
     steps:
       - name: Checkout
-        if: github.event_name == 'pull_request'
+        if: github.event_name != 'workflow_dispatch'
         uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
 
       - name: Filter paths
-        if: github.event_name == 'pull_request'
+        if: github.event_name != 'workflow_dispatch'
         uses: dorny/paths-filter@v3
         id: filter
         with:
@@ -33,6 +34,7 @@ jobs:
   check:
     name: Check Ubuntu
     needs: changes
+    if: github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout
@@ -71,7 +73,9 @@ jobs:
   check-windows:
     name: Check Windows (Rust)
     needs: changes
-    if: needs.changes.outputs.rust == 'true'
+    if: >-
+      (github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch') &&
+      needs.changes.outputs.rust == 'true'
     runs-on: windows-latest
     steps:
       - name: Checkout
@@ -96,10 +100,12 @@ jobs:
         run: cargo build
 
   # Warm target/release on the default branch so tag builds can restore it.
-  # GitHub cache is ref-scoped: tags cannot see other tags, but they can see main.
+  # Only when src-tauri changes (or manual dispatch). Frontend merges must not
+  # pay for a 3-platform release compile.
   release-compile:
     name: Release compile ${{ matrix.display }}
-    if: github.event_name != 'pull_request'
+    needs: changes
+    if: github.event_name != 'pull_request' && needs.changes.outputs.rust == 'true'
     runs-on: ${{ matrix.platform }}
     env:
       CARGO_PROFILE_RELEASE_LTO: "false"
@@ -159,7 +165,8 @@ jobs:
 
   release-compile-windows:
     name: Release compile Windows x64
-    if: github.event_name != 'pull_request'
+    needs: changes
+    if: github.event_name != 'pull_request' && needs.changes.outputs.rust == 'true'
     runs-on: windows-latest
     env:
       CARGO_PROFILE_RELEASE_LTO: "false"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
`#67` 是前端-only 合进 `main`，却又拉起 Linux / macOS / Windows 三台 `cargo build --release`。debug check 已经按 Rust 门控了，release 预热还写着 `if: event != pull_request`，等于 **每次 merge 都付一次发版编译**。

## 改动

- `Detect changes` 在 `push` 到 main 也跑。
- `release-compile` / `release-compile-windows` 只在 `src-tauri/**` 有改动，或 `workflow_dispatch` 时跑。
- debug check 仍然只在 PR / 手动触发，main 上不重跑。

## 这次 PR 自己会跑什么

只改了 `.github/workflows/ci.yml`，没有 `src-tauri`。预期：Ubuntu check；Windows debug skip；三平台 release skip。

正在跑的 https://github.com/Mochocyang/QMAI/actions/runs/31932533636 可以取消，合这个 PR 之前每次前端 merge 都会再烧一轮。

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2c8777f3-244b-40db-8b0b-45927f60e1da?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2c8777f3-244b-40db-8b0b-45927f60e1da&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

