### PR TITLE
release: 升级版本至 3.2.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "qmai",
-  "version": "3.2.2",
+  "version": "3.2.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "qmai",
-      "version": "3.2.2",
+      "version": "3.2.3",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "@base-ui/react": "^1.7.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "qmai",
   "private": true,
-  "version": "3.2.2",
+  "version": "3.2.3",
   "license": "GPL-3.0-or-later",
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -5793,7 +5793,7 @@ checksum = "d55d956fa96f5ec02be2e13af0e20391a5aa83d6a074e3ad368959d0fab299ea"
 
 [[package]]
 name = "qmai"
-version = "3.2.2"
+version = "3.2.3"
 dependencies = [
  "arrow-array",
  "arrow-schema",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "qmai"
-version = "3.2.2"
+version = "3.2.3"
 description = "QMAI - AI writing system for long-form novels"
 authors = ["Mochocyang"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "QMaiWrite",
-  "version": "3.2.2",
+  "version": "3.2.3",
   "identifier": "com.qingmuai.writer",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/src/lib/changelog.spec.ts
+++ b/src/lib/changelog.spec.ts
@@ -6,7 +6,7 @@ describe("changelog", () => {
     const entries = allChangelog()
     const versions = entries.map((entry) => entry.version)
 
-    expect(versions.slice(0, 3)).toEqual(["3.2.2", "3.2.1", "3.2.0"])
+    expect(versions.slice(0, 3)).toEqual(["3.2.3", "3.2.2", "3.2.1"])
     expect(versions).toContain("3.0.9")
     expect(versions).toContain("2.2.37")
     expect(versions).toContain("2.1.0")

--- a/src/lib/changelog.ts
+++ b/src/lib/changelog.ts
@@ -7,6 +7,25 @@ export interface ChangelogEntry {
   };
 }
 
+const THREE_POINT_TWO_THREE_CHANGELOG: ChangelogEntry = {
+  version: "3.2.3",
+  date: "2026-08-16",
+  highlights: {
+    en: [
+      "[Fast Mode Uses Your Selected Model] Fast mode now writes with the writing model you pick in the chat box, instead of silently switching to the default model.",
+      "[@ Skills Now Applied When Writing] Skills you pick with @, or skill names you type, now actually get used when writing chapters.",
+      "[Outline Standard Mode Visible Again] Standard-mode generation steps show up in the conversation again, and the cards no longer flicker.",
+      "[Context Usage Bar No Longer Looks Full] The usage bar fills against the context limit, so half used looks half full.",
+    ],
+    zh: [
+      "【快速模式用你选的写作模型】快速模式会用聊天框里选中的写作模型来写，不再偷偷换成默认模型",
+      "【写正文时真正用上 @技能】用 @ 选中的技能，或直接写技能名，写章节时都会真正用上",
+      "【大纲标准模式过程重新看得见】标准模式生成时，过程重新显示在对话里，卡片也不再闪来闪去",
+      "【上下文用量条不再虚满】用量条按上下文上限显示，用了一半就显示一半，不会半满却铺满整根",
+    ],
+  },
+};
+
 const THREE_POINT_TWO_TWO_CHANGELOG: ChangelogEntry = {
   version: "3.2.2",
   date: "2026-08-15",
@@ -1195,6 +1214,7 @@ function isMergedOnePointRelease(version: string): boolean {
 }
 
 export const CHANGELOG: ChangelogEntry[] = [
+  THREE_POINT_TWO_THREE_CHANGELOG,
   THREE_POINT_TWO_TWO_CHANGELOG,
   THREE_POINT_TWO_ONE_CHANGELOG,
   THREE_POINT_TWO_ZERO_CHANGELOG,
@@ -1263,6 +1283,8 @@ export const CHANGELOG: ChangelogEntry[] = [
 ];
 
 export function currentVersionChangelog(version: string): ChangelogEntry[] {
+  if (version === THREE_POINT_TWO_THREE_CHANGELOG.version)
+    return [THREE_POINT_TWO_THREE_CHANGELOG];
   if (version === THREE_POINT_TWO_TWO_CHANGELOG.version)
     return [THREE_POINT_TWO_TWO_CHANGELOG];
   if (version === THREE_POINT_TWO_ONE_CHANGELOG.version)
@@ -1372,6 +1394,7 @@ export function currentVersionChangelog(version: string): ChangelogEntry[] {
 
 export function allChangelog(): ChangelogEntry[] {
   return [
+    THREE_POINT_TWO_THREE_CHANGELOG,
     THREE_POINT_TWO_TWO_CHANGELOG,
     THREE_POINT_TWO_ONE_CHANGELOG,
     THREE_POINT_TWO_ZERO_CHANGELOG,
@@ -1425,6 +1448,7 @@ export function allChangelog(): ChangelogEntry[] {
     TWO_POINT_ZERO_CHANGELOG,
     ...CHANGELOG.filter(
       (entry) =>
+        entry !== THREE_POINT_TWO_THREE_CHANGELOG &&
         entry !== THREE_POINT_TWO_TWO_CHANGELOG &&
         entry !== THREE_POINT_TWO_ONE_CHANGELOG &&
         entry !== THREE_POINT_TWO_ZERO_CHANGELOG &&


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
将版本升级到 3.2.3，收录 3.2.2 之后已合入的用户可见改动。CI / 打包流水线改动不写进用户更新日志。

## 版本号

同步更新：

- `package.json` / `package-lock.json`
- `src-tauri/Cargo.toml` / `src-tauri/Cargo.lock`
- `src-tauri/tauri.conf.json`

## 更新日志（3.2.3）

1. 【快速模式用你选的写作模型】快速模式会用聊天框里选中的写作模型来写，不再偷偷换成默认模型（#66）
2. 【写正文时真正用上 @技能】用 @ 选中的技能，或直接写技能名，写章节时都会真正用上（#61）
3. 【大纲标准模式过程重新看得见】标准模式生成时，过程重新显示在对话里，卡片也不再闪来闪去（#62、#63）
4. 【上下文用量条不再虚满】用量条按上下文上限显示，用了一半就显示一半，不会半满却铺满整根（#67）

合入后打 `v3.2.3` tag 即可走正式发布流水线。

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9e795ab4-ac8f-4298-9d77-bfe4308decb2?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9e795ab4-ac8f-4298-9d77-bfe4308decb2&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

