### PR TITLE
release: 升级版本至 3.2.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "qmai",
-  "version": "3.2.3",
+  "version": "3.2.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "qmai",
-      "version": "3.2.3",
+      "version": "3.2.4",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "@base-ui/react": "^1.7.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "qmai",
   "private": true,
-  "version": "3.2.3",
+  "version": "3.2.4",
   "license": "GPL-3.0-or-later",
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -5793,7 +5793,7 @@ checksum = "d55d956fa96f5ec02be2e13af0e20391a5aa83d6a074e3ad368959d0fab299ea"
 
 [[package]]
 name = "qmai"
-version = "3.2.3"
+version = "3.2.4"
 dependencies = [
  "arrow-array",
  "arrow-schema",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "qmai"
-version = "3.2.3"
+version = "3.2.4"
 description = "QMAI - AI writing system for long-form novels"
 authors = ["Mochocyang"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "QMaiWrite",
-  "version": "3.2.3",
+  "version": "3.2.4",
   "identifier": "com.qingmuai.writer",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/src/lib/changelog.spec.ts
+++ b/src/lib/changelog.spec.ts
@@ -6,7 +6,7 @@ describe("changelog", () => {
     const entries = allChangelog()
     const versions = entries.map((entry) => entry.version)
 
-    expect(versions.slice(0, 3)).toEqual(["3.2.3", "3.2.2", "3.2.1"])
+    expect(versions.slice(0, 3)).toEqual(["3.2.4", "3.2.3", "3.2.2"])
     expect(versions).toContain("3.0.9")
     expect(versions).toContain("2.2.37")
     expect(versions).toContain("2.1.0")

--- a/src/lib/changelog.ts
+++ b/src/lib/changelog.ts
@@ -7,6 +7,19 @@ export interface ChangelogEntry {
   };
 }
 
+const THREE_POINT_TWO_FOUR_CHANGELOG: ChangelogEntry = {
+  version: "3.2.4",
+  date: "2026-08-16",
+  highlights: {
+    en: [
+      "[Fast/Standard Mode Copy] Fast and Standard modes no longer preview that they will enter review or de-AI polishing; process copy now matches the actual flow, which finishes after the draft.",
+    ],
+    zh: [
+      "【快速/标准模式文案】快速和标准模式不再预告会进入审稿和去AI味，过程说明和实际流程一致",
+    ],
+  },
+};
+
 const THREE_POINT_TWO_THREE_CHANGELOG: ChangelogEntry = {
   version: "3.2.3",
   date: "2026-08-16",
@@ -1214,6 +1227,7 @@ function isMergedOnePointRelease(version: string): boolean {
 }
 
 export const CHANGELOG: ChangelogEntry[] = [
+  THREE_POINT_TWO_FOUR_CHANGELOG,
   THREE_POINT_TWO_THREE_CHANGELOG,
   THREE_POINT_TWO_TWO_CHANGELOG,
   THREE_POINT_TWO_ONE_CHANGELOG,
@@ -1283,6 +1297,8 @@ export const CHANGELOG: ChangelogEntry[] = [
 ];
 
 export function currentVersionChangelog(version: string): ChangelogEntry[] {
+  if (version === THREE_POINT_TWO_FOUR_CHANGELOG.version)
+    return [THREE_POINT_TWO_FOUR_CHANGELOG];
   if (version === THREE_POINT_TWO_THREE_CHANGELOG.version)
     return [THREE_POINT_TWO_THREE_CHANGELOG];
   if (version === THREE_POINT_TWO_TWO_CHANGELOG.version)
@@ -1394,6 +1410,7 @@ export function currentVersionChangelog(version: string): ChangelogEntry[] {
 
 export function allChangelog(): ChangelogEntry[] {
   return [
+    THREE_POINT_TWO_FOUR_CHANGELOG,
     THREE_POINT_TWO_THREE_CHANGELOG,
     THREE_POINT_TWO_TWO_CHANGELOG,
     THREE_POINT_TWO_ONE_CHANGELOG,
@@ -1448,6 +1465,7 @@ export function allChangelog(): ChangelogEntry[] {
     TWO_POINT_ZERO_CHANGELOG,
     ...CHANGELOG.filter(
       (entry) =>
+        entry !== THREE_POINT_TWO_FOUR_CHANGELOG &&
         entry !== THREE_POINT_TWO_THREE_CHANGELOG &&
         entry !== THREE_POINT_TWO_TWO_CHANGELOG &&
         entry !== THREE_POINT_TWO_ONE_CHANGELOG &&


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
将版本升级到 3.2.4，收录 3.2.3 之后已合入的用户可见改动。CI / 打包流水线改动不写进用户更新日志。

## 版本号

同步更新：

- `package.json` / `package-lock.json`
- `src-tauri/Cargo.toml` / `src-tauri/Cargo.lock`
- `src-tauri/tauri.conf.json`

## 更新日志（3.2.4）

1. 【快速/标准模式文案】快速和标准模式不再预告会进入审稿和去AI味，过程说明和实际流程一致（#70）

合入后打 `v3.2.4` tag 即可走正式发布流水线。

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-85af2b48-fea7-4a8a-ab72-b92d1693a64c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-85af2b48-fea7-4a8a-ab72-b92d1693a64c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

